### PR TITLE
Fixing accessor methods

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -78,7 +78,7 @@ class TwitterOAuth {
       $parameters['oauth_callback'] = $oauth_callback;
     } 
     $request = $this->oAuthRequest($this->requestTokenURL(), 'GET', $parameters);
-	return $this->getToken($request);
+    return $this->getToken($request);
   }
 
   /**
@@ -251,3 +251,4 @@ class TwitterOAuth {
 	return $token;
   }
 }
+


### PR DESCRIPTION
A tiny patch that fixes accessor methods.
1. Was referring to the wrong? variable.
2. Taken out since no code is there to support/save which api call was used. I guess this was WIP?

Thank you,

Gena01
