### PR TITLE
Correct Search API endpoint

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -19,6 +19,8 @@ class TwitterOAuth {
   public $url;
   /* Set up the API root URL. */
   public $host = "https://api.twitter.com/1/";
+  /* Set up the Search API root URL. */
+  public $search_host = "https://search.twitter.com/";
   /* Set timeout default. */
   public $timeout = 30;
   /* Set connect timeout. */
@@ -145,6 +147,9 @@ class TwitterOAuth {
    * GET wrapper for oAuthRequest.
    */
   function get($url, $parameters = array()) {
+    if ($url === 'search') {
+      $this->host = $this->search_host;
+    }
     $response = $this->oAuthRequest($url, 'GET', $parameters);
     if ($this->format === 'json' && $this->decode_json) {
       return json_decode($response);
@@ -208,10 +213,9 @@ class TwitterOAuth {
     curl_setopt($ci, CURLOPT_SSL_VERIFYPEER, $this->ssl_verifypeer);
     curl_setopt($ci, CURLOPT_HEADERFUNCTION, array($this, 'getHeader'));
     curl_setopt($ci, CURLOPT_HEADER, FALSE);
-    
     if (!empty($this->ip)) {
-	curl_setopt($ci, CURLOPT_INTERFACE, $this->ip);
-}
+      curl_setopt($ci, CURLOPT_INTERFACE, $this->ip);
+    }
 
     switch ($method) {
       case 'POST':


### PR DESCRIPTION
When you do a get request with the 'search' parameter it will point to the wrong endpoint (https://api.twitter.com/1/search), but the correct endpoint is https://search.twitter.com/search. 

While the Search API is not necessarily used through OAuth, I think it's best to include this different endpoint in the class, and switch to it when needed, to prevent any debugging frustration and unnecessary/unsupported API calls to Twitter.
