### PR TITLE
Added support for specifying access level on request token requests

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -72,11 +72,14 @@ class TwitterOAuth {
    *
    * @returns a key/value array containing oauth_token and oauth_token_secret
    */
-  function getRequestToken($oauth_callback = NULL) {
+  function getRequestToken($oauth_callback = NULL, $access_type = NULL) {
     $parameters = array();
     if (!empty($oauth_callback)) {
       $parameters['oauth_callback'] = $oauth_callback;
-    } 
+    }
+    if (!empty($access_type)) {
+      $parameters['x_auth_access_type'] = $access_type;
+    }
     $request = $this->oAuthRequest($this->requestTokenURL(), 'GET', $parameters);
     $token = OAuthUtil::parse_parameters($request);
     $this->token = new OAuthConsumer($token['oauth_token'], $token['oauth_token_secret']);


### PR DESCRIPTION
Added support for specifying access level on request token requests through "x_auth_access_type" as documented in: http://dev.twitter.com/doc/post/oauth/request_token