### PR TITLE
Three demo files and a help file for oob oauth login

### DIFF
--- a/oob1.php
+++ b/oob1.php
@@ -1,0 +1,23 @@
+<?php
+/**
+* Use this script for out-of-bounds twitter oauth login (e.g. for commandline apps)
+*
+* It is based on redirect.php
+*/
+
+/* Start session and load library. */
+require_once('twitteroauth/twitteroauth.php');
+require_once('config.php');
+
+/* Build TwitterOAuth object with client credentials. */
+$connection = new TwitterOAuth(CONSUMER_KEY, CONSUMER_SECRET);
+ 
+/* Get temporary credentials. */
+$request_token = $connection->getRequestToken(OAUTH_CALLBACK);
+
+file_put_contents("oauth_token.dat",serialize($request_token));
+
+/* Build authorize URL and tell user to visit Twitter. */
+$url = $connection->getAuthorizeURL($request_token['oauth_token'],$sign_in_with_twitter = TRUE); //For all from a browser
+echo "Please visit this URL to authorize the app and get a PIN number:\n  $url\n";
+?>

--- a/oob2.php
+++ b/oob2.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Use this after running oob1.php, after you have the PIN code
+ *
+ * This is based on callback.php
+ *
+ * It takes the PIN code as first parameter.
+ */
+
+
+/* Load lib */
+require_once('twitteroauth/twitteroauth.php');
+require_once('config.php');
+
+
+if(!file_exists("oauth_token.dat")){
+    fwrite(STDERR,"Please run oob1.php first. It will create \"oauth_token.dat\"\n");
+    exit;
+    }
+
+if($argc!=2){
+    fwrite(STDERR,"Must give exactly one param: the PIN code\n");
+    exit;
+    }
+
+$pin=$argv[1];
+
+
+$request_token=unserialize(file_get_contents("oauth_token.dat"));
+
+/* Create TwitterOAuth object with app key/secret and token key/secret from default phase */
+$connection = new TwitterOAuth(CONSUMER_KEY, CONSUMER_SECRET,
+    $request_token['oauth_token'],$request_token['oauth_token_secret']);
+
+/* Request access tokens from twitter */
+$access_token = $connection->getAccessToken($pin);
+
+if($connection->http_code!=200){
+    fwrite(STDERR,"Failed to getAccessToken; http error:{$connection->http_code}\n");print_r($access_token);
+    exit;
+    }
+
+if(!array_key_exists('oauth_token',$access_token)){
+    fwrite(STDERR,"Failed to getAccessToken:\n");print_r($access_token);
+    exit;
+    }
+
+file_put_contents("oauth_success.dat",serialize($access_token));
+unlink("oauth_token.dat");  //Not needed any more
+
+print_r($access_token); //Just for debug
+?>

--- a/oob3.php
+++ b/oob3.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+* Example of how to use commandline, once PIN accepted.
+*
+* It takes one required param, which is the command, and one of:
+*     sut:  statuses/user_timeline
+*     av:   account/verify_credentials
+*     up:  statuses/update: 2nd param is the tweet to post
+*     sd:   statuses/destroy: 2nd param is a tweet ID
+*
+* (Any other command that takes no parameters can be used too.)
+*/
+
+require_once('twitteroauth/twitteroauth.php');
+require_once('config.php');
+
+if($argc<2){
+    fwrite(STDERR,"Must give at least one param: the command\n");
+    exit;
+    }
+
+$command=$argv[1];
+$p1=trim(array_key_exists(2,$argv)?$argv[2]:'');
+
+if(!file_exists("oauth_success.dat")){
+    fwrite(STDERR,"Please run oob2.php first. It will create \"oauth_success.dat\"\n");
+    exit;
+    }
+
+
+//Get the keys to the user's account
+$access_token=unserialize(file_get_contents("oauth_success.dat"));
+
+/* Create a TwitterOauth object with consumer/user tokens. */
+$connection = new TwitterOAuth(CONSUMER_KEY, CONSUMER_SECRET, $access_token['oauth_token'], $access_token['oauth_token_secret']);
+
+switch($command){   //Expand out abbreviations
+    case 'sut':$command='statuses/user_timeline';break;
+    case 'av':$command='account/verify_credentials';break;
+    case 'up':$command='statuses/update';break;
+    case 'sd':$command='statuses/destroy';break;
+    }
+
+switch($command){
+    case 'statuses/update':
+        if(!$p1)$content="ERROR: must give 2nd param, for the tweet to send.";
+        else $content = $connection->post('statuses/update', array('status' => $p1));
+        break;
+
+    case 'statuses/destroy':
+        if(!$p1)$content="ERROR: give the ID of the tweet to delete. Run statuses/user_timeline to discover the id.";
+        else $content =$connection->post('statuses/destroy', array('id' => $p1));
+        break;
+
+    default:    //Assume no parameters
+        $content = $connection->get($command);
+        break;
+    }
+
+
+if(is_string($content))fwrite(STDERR,$content."\n");
+elseif(!$content)fwrite(STDERR,"ERROR: unrecognized command, or network problem.\n");
+else print_r($content);
+
+?>

--- a/oob_readme.txt
+++ b/oob_readme.txt
@@ -1,0 +1,20 @@
+
+Step One:
+   Edit config.php, to set:
+      define('OAUTH_CALLBACK', 'oob');
+
+  (If not already done, go to https://dev.twitter.com/apps, create and configure the app, and add the consumer key and secret to config.php.)
+
+Step Two:
+   php oob1.php
+
+Step Three:
+   Visit the URL it tells you to, and approve the application
+
+Step Four:
+   php oob2.php 1234567
+  (where 1234567 is the PIN number you got at the end of step three)
+
+Step Five:
+   php oob3.php account/verify_credentials
+ (will show your account; see the source for other supported commands, and some shortcuts.)


### PR DESCRIPTION
Examples of how to use twitteroauth completely from the commandline (using the oob callback), including documentation.
This can be used from behind a firewall (i.e. no need to put any files on a live web server).

The required functionality is already all in twitteroauth, but it is very hard to find full working examples, so I think a small number of people will find this very useful. It would have saved me 2-3 hours.

I'm happy to merge oob_readme.txt into the DOCUMENTATION file if you think that makes more sense.
