### PR TITLE
Replaced multiple curl_setopt with a curl_setopt_array

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -195,38 +195,42 @@ class TwitterOAuth {
    * @return API results
    */
   function http($url, $method, $postfields = NULL) {
-    $this->http_info = array();
-    $ci = curl_init();
+
     /* Curl settings */
-    curl_setopt($ci, CURLOPT_USERAGENT, $this->useragent);
-    curl_setopt($ci, CURLOPT_CONNECTTIMEOUT, $this->connecttimeout);
-    curl_setopt($ci, CURLOPT_TIMEOUT, $this->timeout);
-    curl_setopt($ci, CURLOPT_RETURNTRANSFER, TRUE);
-    curl_setopt($ci, CURLOPT_HTTPHEADER, array('Expect:'));
-    curl_setopt($ci, CURLOPT_SSL_VERIFYPEER, $this->ssl_verifypeer);
-    curl_setopt($ci, CURLOPT_HEADERFUNCTION, array($this, 'getHeader'));
-    curl_setopt($ci, CURLOPT_HEADER, FALSE);
+    $options = array(
+      CURLOPT_USERAGENT => $this->useragent,
+      CURLOPT_CONNECTTIMEOUT => $this->connecttimeout,
+      CURLOPT_TIMEOUT => $this->timeout,
+      CURLOPT_RETURNTRANSFER => TRUE,
+      CURLOPT_HTTPHEADER => array('Expect:'),
+      CURLOPT_SSL_VERIFYPEER => $this->ssl_verifypeer,
+      CURLOPT_HEADERFUNCTION => array($this, 'getHeader'),
+      CURLOPT_HEADER => FALSE
+    );
 
     switch ($method) {
       case 'POST':
-        curl_setopt($ci, CURLOPT_POST, TRUE);
+        $options[] = array(CURLOPT_POST => TRUE);
         if (!empty($postfields)) {
-          curl_setopt($ci, CURLOPT_POSTFIELDS, $postfields);
+          $options[] = array(CURLOPT_POSTFIELDS => $postfields);
         }
         break;
       case 'DELETE':
-        curl_setopt($ci, CURLOPT_CUSTOMREQUEST, 'DELETE');
+        $options[] = array(CURLOPT_CUSTOMREQUEST => 'DELETE');
         if (!empty($postfields)) {
           $url = "{$url}?{$postfields}";
+          $options[] = array(CURLOPT_URL => $url);
         }
     }
 
-    curl_setopt($ci, CURLOPT_URL, $url);
+    $ci = curl_init();
+    curl_setopt_array($ci, $options);
     $response = curl_exec($ci);
     $this->http_code = curl_getinfo($ci, CURLINFO_HTTP_CODE);
-    $this->http_info = array_merge($this->http_info, curl_getinfo($ci));
+    $this->http_info = curl_getinfo($ci);
     $this->url = $url;
-    curl_close ($ci);
+    curl_close($ci);
+
     return $response;
   }
 


### PR DESCRIPTION
Here are the points of my argument for this PR.

First, the requirement of using `curl_setopt_array` is satisfied. `json_decode` needs PHP 5.2.0 and higher and `curl_setopt_array` needs PHP 5.1.3 and higher.

Second,  the logic of using `curl_setopt_array` is more clear than that of using `curl_setopt`. `curl_setopt_array` promote the separation of the concerns about preparing the options and the initialization of the curl.

Third, `curl_setopt_array` is slightly faster than mutiple `curl_setopt`. Here is my benchmark code.

https://gist.github.com/3330620

Lastly, I deleted the lines of initialzing `$this->http_info` and using `array_merge`. These lines do nothing.

``` php
$this->http_info = array();
$this->http_info = array_merge($this->http_info, curl_getinfo($ci));
```

Thanks.
