### PR TITLE
added namespace support and PS-0 compatible autoloader

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,5 @@
+<?php
+require_once 'src/autoloader.php';
+
+$splClassLoader = new SplClassLoader("Abraham", "src");
+$splClassLoader->register();

--- a/callback.php
+++ b/callback.php
@@ -5,15 +5,19 @@
  * Verify credentials and redirect to based on response from Twitter.
  */
 
+// Import TwitterOAuth from it's namespace
+use Abraham\TwitterOAuth\TwitterOAuth;
+
 /* Start session and load lib */
 session_start();
-require_once('twitteroauth/twitteroauth.php');
+require_once('autoload.php');
 require_once('config.php');
 
 /* If the oauth_token is old redirect to the connect page. */
-if (isset($_REQUEST['oauth_token']) && $_SESSION['oauth_token'] !== $_REQUEST['oauth_token']) {
-  $_SESSION['oauth_status'] = 'oldtoken';
-  header('Location: ./clearsessions.php');
+if (isset($_REQUEST['oauth_token']) && $_SESSION['oauth_token'] !== $_REQUEST['oauth_token'])
+{
+    $_SESSION['oauth_status'] = 'oldtoken';
+    header('Location: ./clearsessions.php');
 }
 
 /* Create TwitteroAuth object with app key/secret and token key/secret from default phase */
@@ -30,11 +34,14 @@ unset($_SESSION['oauth_token']);
 unset($_SESSION['oauth_token_secret']);
 
 /* If HTTP response is 200 continue otherwise send to connect page to retry */
-if (200 == $connection->http_code) {
-  /* The user has been verified and the access tokens can be saved for future use */
-  $_SESSION['status'] = 'verified';
-  header('Location: ./index.php');
-} else {
-  /* Save HTTP status for error dialog on connnect page.*/
-  header('Location: ./clearsessions.php');
+if (200 == $connection->http_code)
+{
+    /* The user has been verified and the access tokens can be saved for future use */
+    $_SESSION['status'] = 'verified';
+    header('Location: ./index.php');
+}
+else
+{
+    /* Save HTTP status for error dialog on connnect page.*/
+    header('Location: ./clearsessions.php');
 }

--- a/config.php
+++ b/config.php
@@ -5,6 +5,6 @@
  * A single location to store configuration.
  */
 
-define('CONSUMER_KEY', 'CONSUMER_KEY_HERE');
-define('CONSUMER_SECRET', 'CONSUMER_SECRET_HERE');
+define('CONSUMER_KEY', 'CONSUMER KEY HERE');
+define('CONSUMER_SECRET', 'CONSUMER SECRET HERE');
 define('OAUTH_CALLBACK', 'http://example.com/twitteroauth/callback.php');

--- a/index.php
+++ b/index.php
@@ -1,12 +1,18 @@
 <?php
+
+
 /**
  * @file
  * User has successfully authenticated with Twitter. Access tokens saved to session and DB.
  */
 
+// Import TwitterOAuth from it's namespace
+use Abraham\TwitterOAuth\TwitterOAuth;
+
+
 /* Load required lib files. */
 session_start();
-require_once('twitteroauth/twitteroauth.php');
+require_once('autoload.php');
 require_once('config.php');
 
 /* If access tokens are not available redirect to connect page. */

--- a/redirect.php
+++ b/redirect.php
@@ -1,28 +1,33 @@
 <?php
 
+// Import TwitterOAuth from it's namespace
+use Abraham\TwitterOAuth\TwitterOAuth;
+
+
 /* Start session and load library. */
 session_start();
-require_once('twitteroauth/twitteroauth.php');
+require_once('autoload.php');
 require_once('config.php');
 
 /* Build TwitterOAuth object with client credentials. */
 $connection = new TwitterOAuth(CONSUMER_KEY, CONSUMER_SECRET);
- 
+
 /* Get temporary credentials. */
 $request_token = $connection->getRequestToken(OAUTH_CALLBACK);
 
 /* Save temporary credentials to session. */
 $_SESSION['oauth_token'] = $token = $request_token['oauth_token'];
 $_SESSION['oauth_token_secret'] = $request_token['oauth_token_secret'];
- 
+
 /* If last connection failed don't display authorization link. */
-switch ($connection->http_code) {
-  case 200:
-    /* Build authorize URL and redirect user to Twitter. */
-    $url = $connection->getAuthorizeURL($token);
-    header('Location: ' . $url); 
-    break;
-  default:
-    /* Show notification if something went wrong. */
-    echo 'Could not connect to Twitter. Refresh the page or try again later.';
+switch ($connection->http_code)
+{
+    case 200:
+        /* Build authorize URL and redirect user to Twitter. */
+        $url = $connection->getAuthorizeURL($token);
+        header('Location: ' . $url);
+        break;
+    default:
+        /* Show notification if something went wrong. */
+        echo 'Could not connect to Twitter. Refresh the page or try again later.';
 }

--- a/src/Abraham/TwitterOAuth/OAuth.php
+++ b/src/Abraham/TwitterOAuth/OAuth.php
@@ -1,9 +1,13 @@
 <?php
+
+namespace Abraham\TwitterOAuth;
+
+
 // vim: foldmethod=marker
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
+class OAuthException extends \Exception {
   // pass
 }
 
@@ -718,7 +722,7 @@ class OAuthDataStore {
 class OAuthUtil {
   public static function urlencode_rfc3986($input) {
   if (is_array($input)) {
-    return array_map(array('OAuthUtil', 'urlencode_rfc3986'), $input);
+    return array_map(array('Abraham\TwitterOAuth\OAuthUtil', 'urlencode_rfc3986'), $input);
   } else if (is_scalar($input)) {
     return str_replace(
       '+',

--- a/src/Abraham/TwitterOAuth/TwitterOAuth.php
+++ b/src/Abraham/TwitterOAuth/TwitterOAuth.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Abraham\TwitterOAuth;
+
 /*
  * Abraham Williams (abraham@abrah.am) http://abrah.am
  *

--- a/src/autoloader.php
+++ b/src/autoloader.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * SplClassLoader implementation that implements the technical interoperability
+ * standards for PHP 5.3 namespaces and class names.
+ *
+ * http://groups.google.com/group/php-standards/web/final-proposal
+ *
+ *     // Example which loads classes for the Doctrine Common package in the
+ *     // Doctrine\Common namespace.
+ *     $classLoader = new SplClassLoader('Doctrine\Common', '/path/to/doctrine');
+ *     $classLoader->register();
+ *
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ * @author Roman S. Borschel <roman@code-factory.org>
+ * @author Matthew Weier O'Phinney <matthew@zend.com>
+ * @author Kris Wallsmith <kris.wallsmith@gmail.com>
+ * @author Fabien Potencier <fabien.potencier@symfony-project.org>
+ */
+class SplClassLoader
+{
+    private $_fileExtension = '.php';
+    private $_namespace;
+    private $_includePath;
+    private $_namespaceSeparator = '\\';
+
+    /**
+     * Creates a new <tt>SplClassLoader</tt> that loads classes of the
+     * specified namespace.
+     *
+     * @param string $ns The namespace to use.
+     */
+    public function __construct($ns = null, $includePath = null)
+    {
+        $this->_namespace = $ns;
+        $this->_includePath = $includePath;
+    }
+
+    /**
+     * Sets the namespace separator used by classes in the namespace of this class loader.
+     *
+     * @param string $sep The separator to use.
+     */
+    public function setNamespaceSeparator($sep)
+    {
+        $this->_namespaceSeparator = $sep;
+    }
+
+    /**
+     * Gets the namespace seperator used by classes in the namespace of this class loader.
+     *
+     * @return void
+     */
+    public function getNamespaceSeparator()
+    {
+        return $this->_namespaceSeparator;
+    }
+
+    /**
+     * Sets the base include path for all class files in the namespace of this class loader.
+     *
+     * @param string $includePath
+     */
+    public function setIncludePath($includePath)
+    {
+        $this->_includePath = $includePath;
+    }
+
+    /**
+     * Gets the base include path for all class files in the namespace of this class loader.
+     *
+     * @return string $includePath
+     */
+    public function getIncludePath()
+    {
+        return $this->_includePath;
+    }
+
+    /**
+     * Sets the file extension of class files in the namespace of this class loader.
+     *
+     * @param string $fileExtension
+     */
+    public function setFileExtension($fileExtension)
+    {
+        $this->_fileExtension = $fileExtension;
+    }
+
+    /**
+     * Gets the file extension of class files in the namespace of this class loader.
+     *
+     * @return string $fileExtension
+     */
+    public function getFileExtension()
+    {
+        return $this->_fileExtension;
+    }
+
+    /**
+     * Installs this class loader on the SPL autoload stack.
+     */
+    public function register()
+    {
+        spl_autoload_register(array($this, 'loadClass'));
+    }
+
+    /**
+     * Uninstalls this class loader from the SPL autoloader stack.
+     */
+    public function unregister()
+    {
+        spl_autoload_unregister(array($this, 'loadClass'));
+    }
+
+    /**
+     * Loads the given class or interface.
+     *
+     * @param string $className The name of the class to load.
+     * @return void
+     */
+    public function loadClass($className)
+    {
+        if (null === $this->_namespace || $this->_namespace.$this->_namespaceSeparator === substr($className, 0, strlen($this->_namespace.$this->_namespaceSeparator))) {
+            $fileName = '';
+            $namespace = '';
+            if (false !== ($lastNsPos = strripos($className, $this->_namespaceSeparator))) {
+                $namespace = substr($className, 0, $lastNsPos);
+                $className = substr($className, $lastNsPos + 1);
+                $fileName = str_replace($this->_namespaceSeparator, DIRECTORY_SEPARATOR, $namespace) . DIRECTORY_SEPARATOR;
+            }
+            $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . $this->_fileExtension;
+
+            require ($this->_includePath !== null ? $this->_includePath . DIRECTORY_SEPARATOR : '') . $fileName;
+        }
+    }
+}


### PR DESCRIPTION
I have wrapped the existing codes into "Abraham\TwitterOAuth" namespace and structured it in a PS-0 compatible fashion. I have also included an autoloader to demonstrate the auto loading compatibility. 

The library can be now ported to Composer/Packagist eco system and can be dropped directly into a Symfony2 "src" directory and used without modification. 

If this pull request is accepted, I shall create a composer package out of it as well - so that people could install it as a project dependency easily. 
