### PR TITLE
DOCUMENTATION - Add note about how to use version 1.1 of Twitter API

### DIFF
--- a/DOCUMENTATION
+++ b/DOCUMENTATION
@@ -118,5 +118,5 @@ $content = $connection->get('account/verify_credentials');
 $connection->post('statuses/update', array('status' => 'Text of status here',
 'in_reply_to_status_id' => 123456));
 $content = $connection->delete('statuses/destroy/12345');
-Note that if you need to use version 1.1 of the Twitter API instead of v1, you must set the host property:
-$connection->host = "https://api.twitter.com/1.1/";
+To use version 1.1 of the Twitter API instead of v1, you can call useAPIVersion:
+$connection->useAPIVersion('1.1')

--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -19,6 +19,11 @@ class TwitterOAuth {
   public $url;
   /* Set up the API root URL. */
   public $host = "https://api.twitter.com/1/";
+  /* Map API urls by version for useAPIVersion function */
+  public $hosts_by_version = array(
+    "1"   => "https://api.twitter.com/1/",
+    "1.1" => "https://api.twitter.com/1.1/"
+  );
   /* Set timeout default. */
   public $timeout = 30;
   /* Set connect timeout. */
@@ -241,5 +246,13 @@ class TwitterOAuth {
       $this->http_header[$key] = $value;
     }
     return strlen($header);
+  }
+
+  function useAPIVersion($versionString) {
+    if (!isset($this->hosts_by_version[$versionString])) {
+      throw new Exception("TwitterOAuth: unknown Twitter API version $versionString");
+    }
+    $this->host = $this->hosts_by_version[$versionString];
+    return $this;
   }
 }


### PR DESCRIPTION
Twitter API v1.1 just came out. It is easy to tell the TwitterOAuth class how to use it, but it is not in the docs. I just added a short note to the bottom of the docs.
