### PR TITLE
Fix broken getAccessToken method

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -108,11 +108,9 @@ class TwitterOAuth {
    *                "user_id" => "9436992",
    *                "screen_name" => "abraham")
    */
-  function getAccessToken($oauth_verifier = FALSE) {
+  function getAccessToken($oauth_verifier) {
     $parameters = array();
-    if (!empty($oauth_verifier)) {
-      $parameters['oauth_verifier'] = $oauth_verifier;
-    }
+    $parameters['oauth_verifier'] = $oauth_verifier;
     $request = $this->oAuthRequest($this->accessTokenURL(), 'GET', $parameters);
     $token = OAuthUtil::parse_parameters($request);
     $this->token = new OAuthConsumer($token['oauth_token'], $token['oauth_token_secret']);


### PR DESCRIPTION
since begining of April 2013, the getAccessToken should always pass the oauth_verifier. To force the use of the API to pass it, make the getAccessToken $oauth_parameter mandatory.

All uses of twitteroauth::getAccessToken should pass $_REQUEST['oauth_verifier'] i.e.
$TwitterOAuth->getAccessToken($_REQUEST['oauth_verifier'])

see https://dev.twitter.com/discussions/16443
