### PR TITLE
Update default host setting from 1 to 1.1

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -18,7 +18,7 @@ class TwitterOAuth {
   /* Contains the last API call. */
   public $url;
   /* Set up the API root URL. */
-  public $host = "https://api.twitter.com/1/";
+  public $host = "https://api.twitter.com/1.1/";
   /* Set timeout default. */
   public $timeout = 30;
   /* Set connect timeout. */


### PR DESCRIPTION
As of 11th june the API v1 is not supported anymore. https://dev.twitter.com/blog/api-v1-is-retired
