### PR TITLE
I've changed the API version to 1.1 to work around the 1.0 interface being deprecated; seems to work just fine for us.

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -18,7 +18,7 @@ class TwitterOAuth {
   /* Contains the last API call. */
   public $url;
   /* Set up the API root URL. */
-  public $host = "https://api.twitter.com/1/";
+  public $host = "https://api.twitter.com/1.1/";
   /* Set timeout default. */
   public $timeout = 30;
   /* Set connect timeout. */


### PR DESCRIPTION
Started failing with: The Twitter REST API v1 will soon stop
functioning. Please migrate to API v1.1.
https://dev.twitter.com/docs/api/1.1/overview

Updating to API interface seems all that is needed.
