### PR TITLE
Support coexisting with the OAuth PECL module

### DIFF
--- a/twitteroauth/OAuth.php
+++ b/twitteroauth/OAuth.php
@@ -3,8 +3,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if (!class_exists('OAuthException')) {
+  class OAuthException extends Exception {
+    // pass
+  }
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
This patch checks for the existence of an OAuthException class before defining it, since the PHP OAuth PECL module already defines it, causing a fatal error when this library is included.
