### PR TITLE
Don't try to autoload the OAuthException

### DIFF
--- a/twitteroauth/OAuth.php
+++ b/twitteroauth/OAuth.php
@@ -3,7 +3,7 @@
 
 /* Generic exception class
  */
-if (!class_exists('OAuthException')) {
+if (!class_exists('OAuthException', false)) {
   class OAuthException extends Exception {
     // pass
   }


### PR DESCRIPTION
When checking if OAuthException does exist our autoloader found it.. in the OAuth.php file currently being loaded resulting in loading the file twice.

As this check is ment to check if the OAuth extension is loaded an even better solution may be.

```
if (!extension_loaded('oauth'))
```

or something like it.
