### PR TITLE
Added a second configuration in config-sample.php

### DIFF
--- a/config-sample.php
+++ b/config-sample.php
@@ -3,8 +3,16 @@
 /**
  * @file
  * A single location to store configuration.
+ * Set dev for local development
+ * set the $dev variable to switch from the config for production or development machine
  */
-
-define('CONSUMER_KEY', 'CONSUMER_KEY_HERE');
-define('CONSUMER_SECRET', 'CONSUMER_SECRET_HERE');
-define('OAUTH_CALLBACK', 'http://example.com/twitteroauth/callback.php');
+$dev = true;
+if ($dev){
+ define('CONSUMER_KEY',    'CONSUMER_KEY_HERE');
+ define('CONSUMER_SECRET', 'CONSUMER_SECRET_HERE');
+ define('OAUTH_CALLBACK',  'http://127.0.0.1/callback.php');
+} else {
+ define('CONSUMER_KEY',    'CONSUMER_KEY_HERE');
+ define('CONSUMER_SECRET', 'CONSUMER_SECRET_HERE');
+ define('OAUTH_CALLBACK',  'http://example/callback.php');
+}


### PR DESCRIPTION
Added a second set of configuration to the config-sample.php file in this way can be created two twitter application in the dev.twitter.com console, one for local development (with the OAUTH_CALLBACK directed to localhost) and one for the production ( with OAUTH_CALLBACK directed to the production server) and to switch between the tywo is only needed to change the variable.
