### PR TITLE
Updated getAuthorizeURL in twitteroauth.php

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -86,14 +86,20 @@ class TwitterOAuth {
    *
    * @returns a string
    */
-  function getAuthorizeURL($token, $sign_in_with_twitter = TRUE) {
+  function getAuthorizeURL($token, $sign_in_with_twitter = TRUE, $urlparams = array()) {
     if (is_array($token)) {
       $token = $token['oauth_token'];
     }
+    $params = "";
+    if (is_array($urlparams)) {
+	   foreach ($urlparams as $urlparamkey=>$urlparamvalue) {
+		   $params .= "&" . $urlparamkey . "=" . $urlparamvalue;
+	   } 
+    }
     if (empty($sign_in_with_twitter)) {
-      return $this->authorizeURL() . "?oauth_token={$token}";
+      return $this->authorizeURL() . "?oauth_token={$token}" . $params;
     } else {
-       return $this->authenticateURL() . "?oauth_token={$token}";
+       return $this->authenticateURL() . "?oauth_token={$token}" . $params;
     }
   }
 


### PR DESCRIPTION
Added the ability for users to pass URL params to the authentication URL, such as force_login and screen_name.

You closed @miteshashar's abraham/twitteroauth#111 awhile ago, but this code change is different in that it leaves it open ended, for future Twitter API changes and parameter additions.

I want `getAuthorizeURL()` to append my URL params - I don't want to get the URL and then have to add the params on the function return. Currently the function returns `?oauth_token=`, but what if some day it doesn't? I don't want to have to parse the function return (`$authorizeurl`) to see if there is an existing param, and then use `?` or `&` - a lot of extra work that the function can just do itself.
