### PR TITLE
Fixed issue if api key/secret is not valid.

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -77,7 +77,9 @@ class TwitterOAuth {
     $parameters['oauth_callback'] = $oauth_callback; 
     $request = $this->oAuthRequest($this->requestTokenURL(), 'GET', $parameters);
     $token = OAuthUtil::parse_parameters($request);
-    $this->token = new OAuthConsumer($token['oauth_token'], $token['oauth_token_secret']);
+    if (!empty($token['oauth_token']) AND !empty($token['oauth_token_secret'])) {
+      $this->token = new OAuthConsumer($token['oauth_token'], $token['oauth_token_secret']);
+    }
     return $token;
   }
 


### PR DESCRIPTION
Added new check when getting request token to avoid php warnings when api key/secret is not valid.
