### PR TITLE
Add force login option for getAuthorizeURL

### DIFF
--- a/twitteroauth/twitteroauth.php
+++ b/twitteroauth/twitteroauth.php
@@ -86,14 +86,19 @@ class TwitterOAuth {
    *
    * @returns a string
    */
-  function getAuthorizeURL($token, $sign_in_with_twitter = TRUE) {
+  function getAuthorizeURL($token, $sign_in_with_twitter = TRUE, $force_login = FALSE ) {
     if (is_array($token)) {
       $token = $token['oauth_token'];
     }
+
+    if( !empty( $force_login ) ){
+      $force_login = '&force_login=true';
+    }
+
     if (empty($sign_in_with_twitter)) {
-      return $this->authorizeURL() . "?oauth_token={$token}";
+      return $this->authorizeURL() . "?oauth_token={$token}$force_login";
     } else {
-       return $this->authenticateURL() . "?oauth_token={$token}";
+       return $this->authenticateURL() . "?oauth_token={$token}$force_login";
     }
   }
 


### PR DESCRIPTION
In accordance with twitter's docs regarding force logins:

https://dev.twitter.com/oauth/reference/get/oauth/authorize
https://dev.twitter.com/oauth/reference/get/oauth/authenticate

I've added an option to force users to login with the getAuthorizeURL.