### PR TITLE
Extract json_decode capabilities to on JsonDecoder class

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -6,6 +6,8 @@
  */
 namespace Abraham\TwitterOAuth;
 
+use Abraham\TwitterOAuth\Util\JsonDecoder;
+
 /**
  * TwitterOAuth class for interacting with the Twitter API.
  *
@@ -239,7 +241,7 @@ class TwitterOAuth
         $request = Request::fromConsumerAndToken($this->consumer, $this->token, $method, $url, $parameters);
         $headers = 'Authorization: Basic ' . $this->encodeAppAuthorization($this->consumer);
         $result = $this->request($request->getNormalizedHttpUrl(), $method, $headers, $parameters);
-        $response = $this->jsonDecode($result);
+        $response = JsonDecoder::decode($result, $this->decodeJsonAsArray);
         $this->lastResponse = $response;
         return $response;
     }
@@ -300,7 +302,7 @@ class TwitterOAuth
         $url = "{$host}/{$this->apiVersion}/{$path}.json";
         $this->lastApiPath = $path;
         $result = $this->oAuthRequest($url, $method, $parameters);
-        $response = $this->jsonDecode($result);
+        $response = JsonDecoder::decode($result, $this->decodeJsonAsArray);
         $this->lastResponse = $response;
 
         return $response;
@@ -311,7 +313,7 @@ class TwitterOAuth
      *
      * @param string $url
      * @param string $method
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return string
      * @throws TwitterOAuthException
@@ -408,26 +410,6 @@ class TwitterOAuth
         curl_close($curlHandle);
 
         return $body;
-    }
-
-    /**
-     * @param string $string JSON to decode
-     *
-     * @return array|object
-     */
-    private function jsonDecode($string)
-    {
-        // BUG: https://bugs.php.net/bug.php?id=63520
-        // Fix from https://github.com/firebase/php-jwt/blob/83b8899cb73d85d648af93f37ec0ac89f4a5bbae/Authentication/JWT.php#L210 via @thaddeusmt
-        if (
-            version_compare(PHP_VERSION, '5.4.0', '>=')
-            && !(defined('JSON_C_VERSION')
-            && PHP_INT_SIZE > 4)
-        ) {
-            return json_decode($string, $this->decodeJsonAsArray, 512, JSON_BIGINT_AS_STRING);
-        } else {
-            return json_decode($string, $this->decodeJsonAsArray);
-        }
     }
 
     /**

--- a/src/Util/JsonDecoder.php
+++ b/src/Util/JsonDecoder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Abraham\TwitterOAuth\Util;
+
+/**
+ * @author louis <louis@systemli.org>
+ */
+class JsonDecoder
+{
+    /**
+     * Decodes a JSON string to stdObject or associative array
+     *
+     * @param string $string
+     * @param bool   $asArray
+     *
+     * @return array|object
+     */
+    public static function decode($string, $asArray = true)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '>=') && !(defined('JSON_C_VERSION') && PHP_INT_SIZE > 4)) {
+            return json_decode($string, $asArray, 512, JSON_BIGINT_AS_STRING);
+        } else {
+            return json_decode($string, $asArray);
+        }
+    }
+}

--- a/tests/Util/JsonDecoderTest.php
+++ b/tests/Util/JsonDecoderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Abraham\TwitterOAuth\Util\JsonDecoder;
+
+class JsonDecoderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider jsonProvider
+     */
+    public function testDecode($input, $asArray, $expected)
+    {
+        $this->assertEquals($expected, JsonDecoder::decode($input, $asArray));
+    }
+
+    public function jsonProvider()
+    {
+        return array(
+            array('[]', true, array()),
+            array('[1,2,3]', true, array(1, 2, 3)),
+            array('[{"id": 556179961825226750}]', true, array(array('id' => 556179961825226750))),
+            array('[]', false, array()),
+            array('[1,2,3]', false, array(1, 2, 3)),
+            array(
+                '[{"id": 556179961825226750}]',
+                false,
+                array(
+                    $this->getClass(function ($object) {
+                        $object->id = 556179961825226750;
+                        return $object;
+                    })
+                )
+            ),
+
+        );
+    }
+
+    /**
+     * @param callable $callable
+     *
+     * @return stdClass
+     */
+    private function getClass(\Closure $callable)
+    {
+        $object = new stdClass();
+
+        return $callable($object);
+    }
+}


### PR DESCRIPTION
The motivation is that this part had several problems in past and it is a utility function. With this decoupling its better testable and the other thing is to reduce functionality in TwitterOAuth which not mainly needed for the specific case.