### PR TITLE
Add possibility to set oauth tokens after assigned to variable

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -80,6 +80,15 @@ class TwitterOAuth
     }
 
     /**
+     * @param string $oauthToken
+     * @param string $oauthTokenSecret
+     */
+    public function setOauthTokens($oauthToken, $oauthTokenSecret)
+    {
+        $this->token = new Token($oauthToken, $oauthTokenSecret);
+    } 
+
+    /**
      * @param string $version
      */
     public function setApiVersion($version)


### PR DESCRIPTION
I register this class in DI as service.
After second login I want verify that user is loged in (stored data in session) & redirect him on right place
Now it is not possible because I must set tokens only over __constructor.