### PR TITLE
Added Exeption if cURL could not use CA certificate File

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -313,6 +313,8 @@ class TwitterOAuth extends Config
                 throw new TwitterOAuthException('The remote servers SSL certificate or SSH md5 fingerprint failed validation.');
             case 56:
                 throw new TwitterOAuthException('Response from server failed or was interrupted.');
+            case 77:
+                throw new TwitterOAuthException('Problem with the SSL CA cert (path? access rights?)');
         }
 
         $this->response->setHttpCode(curl_getinfo($curlHandle, CURLINFO_HTTP_CODE));


### PR DESCRIPTION
We got an PHP Error, because there was no /usr/local/share/ca-certificates/cacert.pem on our server

PHP Error:
Uncaught Exception: TYPO3\Flow\Error\Exception

Message
  Notice: Undefined offset: 1 in
  /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Abraham_TwitterOAuth_TwitterOAuth.php
  line 320

More Information
  Exception code 1
  File           Packages/Framework/TYPO3.Flow/Classes/TYPO3/Flow/Error/ErrorHandler.php line 77
  Reference code 201502122243224a7118

Stack trace

#0 TYPO3\Flow\Error\ErrorHandler::handleError()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Abraham_TwitterOAuth_TwitterOAuth.php:320

#1 Abraham\TwitterOAuth\TwitterOAuth_Original::request()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Abraham_TwitterOAuth_TwitterOAuth.php:251

#2 Abraham\TwitterOAuth\TwitterOAuth_Original::oAuthRequest()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Abraham_TwitterOAuth_TwitterOAuth.php:222

#3 Abraham\TwitterOAuth\TwitterOAuth_Original::http()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Abraham_TwitterOAuth_TwitterOAuth.php:177

#4 Abraham\TwitterOAuth\TwitterOAuth_Original::get()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/acid_SocialFeed_Provider_TwitterProvider.php:34

#5 acid\SocialFeed\Provider\TwitterProvider_Original::import()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/acid_SocialFeed_Command_SocialfeedCommandController.php:64

#6 acid\SocialFeed\Command\SocialfeedCommandController_Original::importCommand()

#7 ::call_user_func_array()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Cli_CommandController.php:240

#8 TYPO3\Flow\Cli\CommandController_Original::callCommandMethod()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Cli_CommandController.php:110

#9 TYPO3\Flow\Cli\CommandController_Original::processRequest()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Mvc_Dispatcher.php:80

#10 TYPO3\Flow\Mvc\Dispatcher_Original::dispatch()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Mvc_Dispatcher.php:298

#11 TYPO3\Flow\Mvc\Dispatcher::dispatch()

#12 ::call_user_func_array()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Mvc_Dispatcher.php:282

#13 TYPO3\Flow\Mvc\Dispatcher::Flow_Aop_Proxy_invokeJoinPoint()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Packages/Framework/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Advice/AdviceChain.php:57

#14 TYPO3\Flow\Aop\Advice\AdviceChain::proceed()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Security_Aspect_RequestDispatchingAspect.php:75

#15 TYPO3\Flow\Security\Aspect\RequestDispatchingAspect_Original::blockIllegalRequestsAndForwardToAuthenticationEntryPoints()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Packages/Framework/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Advice/AroundAdvice.php:34

#16 TYPO3\Flow\Aop\Advice\AroundAdvice::invoke()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Packages/Framework/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Advice/AdviceChain.php:55

#17 TYPO3\Flow\Aop\Advice\AdviceChain::proceed()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Mvc_Dispatcher.php:313

#18 TYPO3\Flow\Mvc\Dispatcher::dispatch()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Packages/Framework/TYPO3.Flow/Classes/TYPO3/Flow/Cli/CommandRequestHandler.php:97

#19 TYPO3\Flow\Cli\CommandRequestHandler::handleRequest()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Packages/Framework/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php:108

#20 TYPO3\Flow\Core\Bootstrap::run()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/Packages/Framework/TYPO3.Flow/Scripts/flow.php:55

#21 ::require()
   /var/customers/webs/jcwebsitedev/TYPO3-Neos/flow:18
