### PR TITLE
FIX: Address issue #338 and throw an exception on all cURL errors.

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -306,15 +306,19 @@ class TwitterOAuth extends Config
         $response = curl_exec($curlHandle);
 
         $curlErrno = curl_errno($curlHandle);
-        switch ($curlErrno) {
-            case 28:
-                throw new TwitterOAuthException('Request timed out.');
-            case 51:
-                throw new TwitterOAuthException('The remote servers SSL certificate or SSH md5 fingerprint failed validation.');
-            case 56:
-                throw new TwitterOAuthException('Response from server failed or was interrupted.');
-            case 77:
-                throw new TwitterOAuthException('Problem with the SSL CA cert (path? access rights?)');
+        if ($curlErrno > 0) {
+            switch ($curlErrno) {
+                case 28:
+                    throw new TwitterOAuthException('Request timed out.');
+                case 51:
+                    throw new TwitterOAuthException('The remote servers SSL certificate or SSH md5 fingerprint failed validation.');
+                case 56:
+                    throw new TwitterOAuthException('Response from server failed or was interrupted.');
+                case 77:
+                    throw new TwitterOAuthException('Problem with the SSL CA cert (path? access rights?)');
+                default:
+                    throw new TwitterOAuthException(curl_error($curlHandle), $curlErrno);
+            }
         }
 
         $this->response->setHttpCode(curl_getinfo($curlHandle, CURLINFO_HTTP_CODE));

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -305,21 +305,9 @@ class TwitterOAuth extends Config
         curl_setopt_array($curlHandle, $options);
         $response = curl_exec($curlHandle);
 
+        // Throw exceptions on cURL errors.
         $curlErrno = curl_errno($curlHandle);
-        if ($curlErrno > 0) {
-            switch ($curlErrno) {
-                case 28:
-                    throw new TwitterOAuthException('Request timed out.');
-                case 51:
-                    throw new TwitterOAuthException('The remote servers SSL certificate or SSH md5 fingerprint failed validation.');
-                case 56:
-                    throw new TwitterOAuthException('Response from server failed or was interrupted.');
-                case 77:
-                    throw new TwitterOAuthException('Problem with the SSL CA cert (path? access rights?)');
-                default:
-                    throw new TwitterOAuthException(curl_error($curlHandle), $curlErrno);
-            }
-        }
+        if ($curlErrno > 0) throw new TwitterOAuthException(curl_error($curlHandle), $curlErrno);
 
         $this->response->setHttpCode(curl_getinfo($curlHandle, CURLINFO_HTTP_CODE));
         $parts = explode("\r\n\r\n", $response);


### PR DESCRIPTION
Fix for issue #338 to reveal mysterious cURL errors (instead of just returning `null`).