### PR TITLE
Add Api host and Api Version by parameter, to support multiple (host …

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -174,7 +174,7 @@ class TwitterOAuth extends Config
      */
     public function get($path, array $parameters = array())
     {
-        return $this->http('GET', self::API_HOST, $path, $parameters);
+        return $this->http('GET', self::API_HOST, self::API_VERSION, $path, $parameters);
     }
 
     /**
@@ -187,7 +187,33 @@ class TwitterOAuth extends Config
      */
     public function post($path, array $parameters = array())
     {
-        return $this->http('POST', self::API_HOST, $path, $parameters);
+        return $this->http('POST', self::API_HOST, self::API_VERSION, $path, $parameters);
+    }
+
+    /**
+     * Make GET requests to the API with Given Host and Version.
+     * Useful for calling Ads API by twitter
+     * @param string $path
+     * @param array  $parameters
+     *
+     * @return array|object
+     */
+    public function getWithHost($apiHost , $apiVersion, $path, array $parameters = array() )
+    {
+        return $this->http('GET', $apiHost, $apiVersion, $path, $parameters);
+    }
+    
+    /**
+     * Make POST requests to the API with given Host and Version.
+     * Useful for calling Ads API by twitter
+     * @param string $path
+     * @param array  $parameters
+     *
+     * @return array|object
+     */
+    public function postWithHost($apiHost , $apiVersion, $path, array $parameters = array() )
+    {
+        return $this->http('POST', $apiHost, $apiVersion, $path, $parameters);
     }
 
     /**
@@ -203,7 +229,7 @@ class TwitterOAuth extends Config
         $file = file_get_contents($parameters['media']);
         $base = base64_encode($file);
         $parameters['media'] = $base;
-        return $this->http('POST', self::UPLOAD_HOST, $path, $parameters);
+        return $this->http('POST', self::UPLOAD_HOST, self::API_VERSION, $path, $parameters);
     }
 
     /**
@@ -214,10 +240,10 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    private function http($method, $host, $path, array $parameters)
+    private function http($method, $host, $apiVersion, $path, array $parameters)
     {
         $this->resetLastResponse();
-        $url = sprintf('%s/%s/%s.json', $host, self::API_VERSION, $path);
+        $url = sprintf('%s/%s/%s.json', $host, $apiVersion, $path);
         $this->response->setApiPath($path);
         $result = $this->oAuthRequest($url, $method, $parameters);
         $response = JsonDecoder::decode($result, $this->decodeJsonAsArray);

--- a/tests/TwitterOAuthTest.php
+++ b/tests/TwitterOAuthTest.php
@@ -236,4 +236,28 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->twitter->getLastHttpCode());
         $this->assertEquals(array(), $this->twitter->getLastBody());
     }
+
+    // Only Works for Application which have "developer/basic/standard" access from Twitter
+    // Details read: https://dev.twitter.com/ads/overview
+    public function testGetAdAccount()
+    {
+        $accountResponse = $this->twitter->getWithHost("https://ads-api-sandbox.twitter.com","0","accounts");
+        $this->assertEquals(200, $this->twitter->getLastHttpCode());
+        return $accountResponse;
+    }
+
+    /**
+     * @depends testGetAdAccount
+     * The App-List created by Ads account test is not possible to delete, for the same purpose sandbox url is used
+     */
+    public function testPostAppListForAdAccount($accountResponse)
+    {
+        $id = $accountResponse->data[0]->id;
+        $params = [
+                "name" => "Test App from Test Case",
+                "app_store_identifiers" => "com.twitter.android,333903271"
+        ];
+        $appListsPost = $this->twitter->postWithHost("https://ads-api-sandbox.twitter.com","0", "accounts/$id/app_lists", $params);
+        $this->assertEquals(200, $this->twitter->getLastHttpCode());
+    }
 }


### PR DESCRIPTION
This addition will allow library to support any kind of Host, the main reason for now is to support the Ads Api URLs. I tried to keep it ad dynamic because it was less change and will allow the developers to think on their own regarding (Sandbox url and version). And this change will also leave system backward compatible.

The other important point is the addition of apiVersion inside http( method, I rearranged the parameter sequence because it is private method! and I think apiVersion should be in-front of host.

It was possible to follow the existing convention and put the URL as constant inside library but I think at this point we just need to add another flexibility to provide any host parameter and its handy to give Sanbox Url of Ads this way.

Note that I also added the test and tested those which works fine! 
