### PR TITLE
Allow the consumer key to be updated after initialization

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -43,7 +43,7 @@ class TwitterOAuth extends Config
         $this->resetLastResponse();
         $this->signatureMethod = new HmacSha1();
         
-        $this->setConsumer($consumerKey, $consumerSercret);
+        $this->setConsumer($consumerKey, $consumerSecret);
         
         if (!empty($oauthToken) && !empty($oauthTokenSecret)) {
             $this->token = new Token($oauthToken, $oauthTokenSecret);

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -62,16 +62,26 @@ class TwitterOAuth extends Config
         $this->token = new Token($oauthToken, $oauthTokenSecret);
     }
     
+    /**
+     * @return Token|null
+     */
     public function getOauthToken()
     {
         return $this->token;
     }
-    
+
+    /**
+     * @param $consumerKey
+     * @param $consumerSecret
+     */
     public function setConsumer($consumerKey, $consumerSecret)
     {
         $this->consumer = new Consumer($consumerKey, $consumerSecret);
     }
-    
+
+    /**
+     * @return Consumer
+     */
     public function getConsumer()
     {
         return $this->consumer;

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -42,7 +42,9 @@ class TwitterOAuth extends Config
     {
         $this->resetLastResponse();
         $this->signatureMethod = new HmacSha1();
-        $this->consumer = new Consumer($consumerKey, $consumerSecret);
+        
+        $this->setConsumer($consumerKey, $consumerSercret);
+        
         if (!empty($oauthToken) && !empty($oauthTokenSecret)) {
             $this->token = new Token($oauthToken, $oauthTokenSecret);
         }
@@ -58,6 +60,21 @@ class TwitterOAuth extends Config
     public function setOauthToken($oauthToken, $oauthTokenSecret)
     {
         $this->token = new Token($oauthToken, $oauthTokenSecret);
+    }
+    
+    public function getOauthToken()
+    {
+        return $this->token;
+    }
+    
+    public function setConsumer($consumerKey, $consumerSecret)
+    {
+        $this->consumer = new Consumer($consumerKey, $consumerSecret);
+    }
+    
+    public function getConsumer()
+    {
+        return $this->consumer;
     }
 
     /**


### PR DESCRIPTION
I need to update the consumer key from a child class but this isn't possible because of the scope of the consumer property. I've just added some utility methods to allow for the consumer to be updated after the object is initialized.
