### PR TITLE
Allow the user to disable the gzip encoding of cURL

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -26,6 +26,9 @@ class Config
     /** @var array Store proxy connection details */
     protected $proxy = [];
 
+    /** @var bool Whether to encode the curl requests with gzip or not */
+    protected $gzipEncoding = true;
+
     /**
      * Set the connection and response timeouts.
      *
@@ -60,5 +63,15 @@ class Config
     public function setProxy(array $proxy)
     {
         $this->proxy = $proxy;
+    }
+
+    /**
+     * Whether to encode the curl requests with gzip or not.
+     *
+     * @param boolean $gzipEncoding
+     */
+    public function setGzipEncoding($gzipEncoding)
+    {
+        $this->gzipEncoding = (bool)$gzipEncoding;
     }
 }

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -360,8 +360,11 @@ class TwitterOAuth extends Config
             CURLOPT_TIMEOUT => $this->timeout,
             CURLOPT_URL => $url,
             CURLOPT_USERAGENT => $this->userAgent,
-            CURLOPT_ENCODING => 'gzip',
         ];
+
+        if($this->gzipEncoding) {
+            $options[CURLOPT_ENCODING] = 'gzip';
+        }
 
         if (!empty($this->proxy)) {
             $options[CURLOPT_PROXY] = $this->proxy['CURLOPT_PROXY'];


### PR DESCRIPTION
On Google App Engine the curl library does not support gzip encoding, so it is useful for the user to allow disable it.