### PR TITLE
support stream upload interface

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -219,6 +219,20 @@ class TwitterOAuth extends Config
     }
 
     /**
+     * Upload media as stream upload.twitter.com
+     *
+     * @param string $path
+     * @param array  $parameters
+     * @param boolean  $chunked
+     *
+     * @return array|object
+     */
+    public function uploadStream($path, array $parameters = [])
+    {
+        return $this->http('POST', self::UPLOAD_HOST, $path, $parameters);
+    }
+
+    /**
      * Upload media to upload.twitter.com.
      *
      * @param string $path


### PR DESCRIPTION
Hi, there is no way to upload media as stream.
I think that there are in demand to deal with stream object directly (using AWS S3).
At this time, we can use "upload" method, however this method is only effective for using "file path".

This PR add interface for streaming upload. (very simple code)

If we want to upload as stream, we can use this method as follows.

```
$object = s3.getObject(...); //object get by AWS
$stream = $object['Body']; //binary data
twitterObject->uploadStream('media/upload', ['media' => $stream]);
```

Best regards.
