### PR TITLE
Exclude dev files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/autoload.php export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/LICENSE.md export-ignore
+/phpmd.xml export-ignore
+/phpunit.xml export-ignore
+/README.md export-ignore
+/tests export-ignore
+/.travis.yml export-ignore


### PR DESCRIPTION
There is no need to include these files when running composer with [`--prefer-dist`](https://getcomposer.org/doc/03-cli.md#install) and if you want them you can use `--prefer-source`. This will save some transferred data when deploying.
