### PR TITLE
Commented out CURLOPT_CAINFO

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -350,7 +350,7 @@ class TwitterOAuth extends Config
         /* Curl settings */
         $options = [
             // CURLOPT_VERBOSE => true,
-            CURLOPT_CAINFO => __DIR__ . DIRECTORY_SEPARATOR . 'cacert.pem',
+            // CURLOPT_CAINFO => __DIR__ . DIRECTORY_SEPARATOR . 'cacert.pem',
             CURLOPT_CONNECTTIMEOUT => $this->connectionTimeout,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => ['Accept: application/json', $authorization, 'Expect:'],


### PR DESCRIPTION
CURLOPT_CAINFO doesn't work in a PHAR package. See: https://bugs.php.net/bug.php?id=69035