### PR TITLE
Phar compression compatibility

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -350,7 +350,7 @@ class TwitterOAuth extends Config
         /* Curl settings */
         $options = [
             // CURLOPT_VERBOSE => true,
-            // CURLOPT_CAINFO => __DIR__ . DIRECTORY_SEPARATOR . 'cacert.pem',
+            CURLOPT_CAINFO => __DIR__ . DIRECTORY_SEPARATOR . 'cacert.pem',
             CURLOPT_CONNECTTIMEOUT => $this->connectionTimeout,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => ['Accept: application/json', $authorization, 'Expect:'],
@@ -361,6 +361,11 @@ class TwitterOAuth extends Config
             CURLOPT_URL => $url,
             CURLOPT_USERAGENT => $this->userAgent,
         ];
+
+        /* Remmove CACert file when in a PHAR file. */
+        if (!empty(Phar::running(false))) {
+            unset($options[CURLOPT_CAINFO]);
+        }
 
         if($this->gzipEncoding) {
             $options[CURLOPT_ENCODING] = 'gzip';

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -363,7 +363,7 @@ class TwitterOAuth extends Config
         ];
 
         /* Remmove CACert file when in a PHAR file. */
-        if (!empty(Phar::running(false))) {
+        if (!empty(\Phar::running(false))) {
             unset($options[CURLOPT_CAINFO]);
         }
 

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -350,7 +350,7 @@ class TwitterOAuth extends Config
         /* Curl settings */
         $options = [
             // CURLOPT_VERBOSE => true,
-            CURLOPT_CAINFO => __DIR__ . DIRECTORY_SEPARATOR . 'cacert.pem',
+            // CURLOPT_CAINFO => __DIR__ . DIRECTORY_SEPARATOR . 'cacert.pem',
             CURLOPT_CONNECTTIMEOUT => $this->connectionTimeout,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => ['Accept: application/json', $authorization, 'Expect:'],

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -362,7 +362,7 @@ class TwitterOAuth extends Config
             CURLOPT_USERAGENT => $this->userAgent,
         ];
 
-        /* Remmove CACert file when in a PHAR file. */
+        /* Remove CACert file when in a PHAR file. */
         if (!empty(\Phar::running(false))) {
             unset($options[CURLOPT_CAINFO]);
         }


### PR DESCRIPTION
When project is compressed into a PHAR file, current Twitteroauth will fail as it can't find load the .pem certificate bundle.

This pull request fixes this issue, the certificate bundle will only be included when the file is not in a Phar file (defaulting to the system certificate bundle).

Related to #486 