### PR TITLE
bump min vesrion to PHP 5.6

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -18,7 +18,7 @@
         "issues": "https://github.com/abraham/twitteroauth/issues"
     },
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6",
         "ext-curl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Since PHP 5.5 is no longer supported https://secure.php.net/supported-versions.php