### PR TITLE
Fix syntax error on PHP 5.4

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -460,6 +460,6 @@ class TwitterOAuth extends Config
      */
     private function pharRunning()
     {
-        return class_exists('Phar') && !empty(\Phar::running(false));
+        return class_exists('Phar') && \Phar::running(false) !== '';
     }
 }


### PR DESCRIPTION
Since PHP 5.4 is still used in [Debian Wheezy][1], which is on LTS until [May 2018][2], support for older versions of PHP would be nice. Fortunately, the library is still compatible with PHP 5.4, except for one small detail.

Use of `empty` on `Phar::running` was replaced by `=== ''` check, since the function only [returns a string][3] and calling `empty` directly on the return of function call is not supported [prior PHP 5.5][4].

[1]: https://wiki.debian.org/PHP#Available_versions
[2]: https://wiki.debian.org/LTS
[3]: https://secure.php.net/manual/en/phar.running.php#refsect1-phar.running-returnvalues
[4]: https://secure.php.net/manual/en/function.empty.php#refsect1-function.empty-parameters