### PR TITLE
Add support to media_category in upload media chunked.

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -263,11 +263,16 @@ class TwitterOAuth extends Config
     private function uploadMediaChunked($path, array $parameters)
     {
         // Init
-        $init = $this->http('POST', self::UPLOAD_HOST, $path, [
+        $init_parameters = [
             'command' => 'INIT',
             'media_type' => $parameters['media_type'],
             'total_bytes' => filesize($parameters['media'])
-        ]);
+        ];
+        if (isset($parameters['media_category']))
+        {
+            $init_parameters['media_category'] = $parameters['media_category'];
+        }
+        $init = $this->http('POST', self::UPLOAD_HOST, $path, $init_parameters);
         // Append
         $segment_index = 0;
         $media = fopen($parameters['media'], 'rb');

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -262,17 +262,7 @@ class TwitterOAuth extends Config
      */
     private function uploadMediaChunked($path, array $parameters)
     {
-        // Init
-        $init_parameters = [
-            'command' => 'INIT',
-            'media_type' => $parameters['media_type'],
-            'total_bytes' => filesize($parameters['media'])
-        ];
-        if (isset($parameters['media_category']))
-        {
-            $init_parameters['media_category'] = $parameters['media_category'];
-        }
-        $init = $this->http('POST', self::UPLOAD_HOST, $path, $init_parameters);
+        $init = $this->http('POST', self::UPLOAD_HOST, $path, $this->mediaInitParameters($parameters));
         // Append
         $segment_index = 0;
         $media = fopen($parameters['media'], 'rb');
@@ -292,6 +282,30 @@ class TwitterOAuth extends Config
             'media_id' => $init->media_id_string
         ]);
         return $finalize;
+    }
+
+    /**
+     * Private method to get params for upload media chunked init.
+     * Twitter docs: https://dev.twitter.com/rest/reference/post/media/upload-init.html
+     *
+     * @param array  $parameters
+     *
+     * @return array
+     */
+    private function mediaInitParameters(array $parameters)
+    {
+        $return = [
+            'command' => 'INIT',
+            'media_type' => $parameters['media_type'],
+            'total_bytes' => filesize($parameters['media'])
+        ];
+        if (isset($parameters['additional_owners'])) {
+            $return['additional_owners'] = $parameters['additional_owners'];
+        }
+        if (isset($parameters['media_category'])) {
+            $return['media_category'] = $parameters['media_category'];
+        }
+        return $return;
     }
 
     /**


### PR DESCRIPTION
This is important because twitter allows to upload videos up to 140 seconds if you can specify a media_category in the media upload endpoint (only in chunked).

Of course the code edit will continue to support calls to the upload method without the media_category in the params.