### PR TITLE
Use array syntax short to improve readability

### DIFF
--- a/tests/AbstractSignatureMethodTest.php
+++ b/tests/AbstractSignatureMethodTest.php
@@ -38,14 +38,14 @@ abstract class AbstractSignatureMethodTest extends \PHPUnit_Framework_TestCase
     protected function getConsumer($key = null, $secret = null, $callbackUrl = null)
     {
         return $this->getMockBuilder('Abraham\TwitterOAuth\Consumer')
-            ->setConstructorArgs(array($key, $secret, $callbackUrl))
+            ->setConstructorArgs([$key, $secret, $callbackUrl])
             ->getMock();
     }
 
     protected function getToken($key = null, $secret = null)
     {
         return $this->getMockBuilder('Abraham\TwitterOAuth\Token')
-            ->setConstructorArgs(array($key, $secret))
+            ->setConstructorArgs([$key, $secret])
             ->getMock();
     }
 }

--- a/tests/HmacSha1Test.php
+++ b/tests/HmacSha1Test.php
@@ -15,21 +15,21 @@ class HmacSha1Test extends AbstractSignatureMethodTest
 
     public function signatureDataProvider()
     {
-        return array(
-            array('5CoEcoq7XoKFjwYCieQvuzadeUA=', $this->getRequest(), $this->getConsumer(), $this->getToken()),
-            array(
+        return [
+            ['5CoEcoq7XoKFjwYCieQvuzadeUA=', $this->getRequest(), $this->getConsumer(), $this->getToken()],
+            [
                 'EBw0gHngam3BTx8kfPfNNSyKem4=',
                 $this->getRequest(),
                 $this->getConsumer('key', 'secret'),
                 $this->getToken()
-            ),
-            array(
+            ],
+            [
                 'kDsHFZzws2a5M6cAQjfpdNBo+v8=',
                 $this->getRequest(),
                 $this->getConsumer('key', 'secret'),
                 $this->getToken('key', 'secret')
-            ),
-            array('EBw0gHngam3BTx8kfPfNNSyKem4=', $this->getRequest(), $this->getConsumer('key', 'secret'), null),
-        );
+            ],
+            ['EBw0gHngam3BTx8kfPfNNSyKem4=', $this->getRequest(), $this->getConsumer('key', 'secret'), null],
+        ];
     }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -17,10 +17,10 @@ class TokenTest extends \PHPUnit_Framework_TestCase {
 
     public function tokenProvider()
     {
-        return array(
-            array('oauth_token=key&oauth_token_secret=secret', 'key', 'secret'),
-            array('oauth_token=key%2Bkey&oauth_token_secret=secret', 'key+key', 'secret'),
-            array('oauth_token=key~key&oauth_token_secret=secret', 'key~key', 'secret'),
-        );
+        return [
+            ['oauth_token=key&oauth_token_secret=secret', 'key', 'secret'],
+            ['oauth_token=key%2Bkey&oauth_token_secret=secret', 'key+key', 'secret'],
+            ['oauth_token=key~key&oauth_token_secret=secret', 'key~key', 'secret'],
+        ];
     }
 }

--- a/tests/TwitterOAuthTest.php
+++ b/tests/TwitterOAuthTest.php
@@ -28,14 +28,14 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
         $twitter->setOauthToken(ACCESS_TOKEN, ACCESS_TOKEN_SECRET);
         $this->assertObjectHasAttribute('consumer', $twitter);
         $this->assertObjectHasAttribute('token', $twitter);
-        $twitter->get('friendships/show', array('target_screen_name' => 'twitterapi'));
+        $twitter->get('friendships/show', ['target_screen_name' => 'twitterapi']);
         $this->assertEquals(200, $twitter->getLastHttpCode());
     }
 
     public function testOauth2Token()
     {
         $twitter = new TwitterOAuth(CONSUMER_KEY, CONSUMER_SECRET);
-        $result = $twitter->oauth2('oauth2/token', array('grant_type' => 'client_credentials'));
+        $result = $twitter->oauth2('oauth2/token', ['grant_type' => 'client_credentials']);
         $this->assertEquals(200, $twitter->getLastHttpCode());
         $this->assertObjectHasAttribute('token_type', $result);
         $this->assertObjectHasAttribute('access_token', $result);
@@ -49,7 +49,7 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
     public function testBearerToken($accessToken)
     {
         $twitter = new TwitterOAuth(CONSUMER_KEY, CONSUMER_SECRET, null, $accessToken->access_token);
-        $result = $twitter->get('statuses/user_timeline', array('screen_name' => 'twitterapi'));
+        $result = $twitter->get('statuses/user_timeline', ['screen_name' => 'twitterapi']);
         if ($twitter->getLastHttpCode() !== 200) {
             $this->assertEquals('foo', substr($accessToken->access_token, 0, 75));
             $this->assertEquals('foo', print_r($result, true));
@@ -78,7 +78,7 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
     public function testOauthRequestToken()
     {
         $twitter = new TwitterOAuth(CONSUMER_KEY, CONSUMER_SECRET);
-        $result = $twitter->oauth('oauth/request_token', array('oauth_callback' => OAUTH_CALLBACK));
+        $result = $twitter->oauth('oauth/request_token', ['oauth_callback' => OAUTH_CALLBACK]);
         $this->assertEquals(200, $twitter->getLastHttpCode());
         $this->assertArrayHasKey('oauth_token', $result);
         $this->assertArrayHasKey('oauth_token_secret', $result);
@@ -94,7 +94,7 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
     public function testOauthRequestTokenException()
     {
         $twitter = new TwitterOAuth('CONSUMER_KEY', 'CONSUMER_SECRET');
-        $result = $twitter->oauth('oauth/request_token', array('oauth_callback' => OAUTH_CALLBACK));
+        $result = $twitter->oauth('oauth/request_token', ['oauth_callback' => OAUTH_CALLBACK]);
         return $result;
     }
 
@@ -112,19 +112,19 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
             $requestToken['oauth_token'],
             $requestToken['oauth_token_secret']
         );
-        $twitter->oauth("oauth/access_token", array("oauth_verifier" => "fake_oauth_verifier"));
+        $twitter->oauth("oauth/access_token", ["oauth_verifier" => "fake_oauth_verifier"]);
     }
 
     public function testUrl()
     {
-        $url = $this->twitter->url('oauth/authorize', array('foo' => 'bar', 'baz' => 'qux'));
+        $url = $this->twitter->url('oauth/authorize', ['foo' => 'bar', 'baz' => 'qux']);
         $this->assertEquals('https://api.twitter.com/oauth/authorize?foo=bar&baz=qux', $url);
     }
 
     public function testGetAccountVerifyCredentials()
     {
         // Include entities boolean added to test parameter value cohearsion
-        $this->twitter->get('account/verify_credentials', array("include_entities" => false));
+        $this->twitter->get('account/verify_credentials', ["include_entities" => false]);
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
     }
 
@@ -150,7 +150,7 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSearchTweets()
     {
-        $result = $this->twitter->get('search/tweets', array('q' => 'twitter'));
+        $result = $this->twitter->get('search/tweets', ['q' => 'twitter']);
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
         return $result->statuses;
     }
@@ -161,13 +161,13 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
     public function testGetSearchTweetsWithMaxId($statuses)
     {
         $maxId = array_pop($statuses)->id_str;
-        $this->twitter->get('search/tweets', array('q' => 'twitter', 'max_id' => $maxId));
+        $this->twitter->get('search/tweets', ['q' => 'twitter', 'max_id' => $maxId]);
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
     }
 
     public function testPostFavoritesCreate()
     {
-        $result = $this->twitter->post('favorites/create', array('id' => '6242973112'));
+        $result = $this->twitter->post('favorites/create', ['id' => '6242973112']);
         if ($this->twitter->getLastHttpCode() == 403) {
             // Status already favorited
             $this->assertEquals(139, $result->errors[0]->code);
@@ -181,7 +181,7 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
      */
     public function testPostFavoritesDestroy()
     {
-        $this->twitter->post('favorites/destroy', array('id' => '6242973112'));
+        $this->twitter->post('favorites/destroy', ['id' => '6242973112']);
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
     }
 
@@ -190,10 +190,10 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
         $this->twitter->setTimeouts(60, 30);
         // Image source https://www.flickr.com/photos/titrans/8548825587/
         $file_path = __DIR__ . '/kitten.jpg';
-        $result = $this->twitter->upload('media/upload', array('media' => $file_path));
+        $result = $this->twitter->upload('media/upload', ['media' => $file_path]);
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
         $this->assertObjectHasAttribute('media_id_string', $result);
-        $parameters = array('status' => 'Hello World ' . time(), 'media_ids' => $result->media_id_string);
+        $parameters = ['status' => 'Hello World ' . time(), 'media_ids' => $result->media_id_string];
         $result = $this->twitter->post('statuses/update', $parameters);
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
         if ($this->twitter->getLastHttpCode() == 200) {
@@ -207,10 +207,10 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
         $this->twitter->setTimeouts(60, 30);
         // Video source http://www.sample-videos.com/
         $file_path = __DIR__ . '/video.mp4';
-        $result = $this->twitter->upload('media/upload', array('media' => $file_path, 'media_type' => 'video/mp4'), true);
+        $result = $this->twitter->upload('media/upload', ['media' => $file_path, 'media_type' => 'video/mp4'], true);
         $this->assertEquals(201, $this->twitter->getLastHttpCode());
         $this->assertObjectHasAttribute('media_id_string', $result);
-        $parameters = array('status' => 'Hello World ' . time(), 'media_ids' => $result->media_id_string);
+        $parameters = ['status' => 'Hello World ' . time(), 'media_ids' => $result->media_id_string];
         $result = $this->twitter->post('statuses/update', $parameters);
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
         if ($this->twitter->getLastHttpCode() == 200) {
@@ -221,7 +221,7 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
 
     public function testPostStatusesUpdateUtf8()
     {
-        $result = $this->twitter->post('statuses/update', array('status' => 'xこんにちは世界 ' . time()));
+        $result = $this->twitter->post('statuses/update', ['status' => 'xこんにちは世界 ' . time()]);
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
         return $result;
     }
@@ -237,7 +237,7 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
 
     public function testLastResult()
     {
-        $this->twitter->get('search/tweets', array('q' => 'twitter'));
+        $this->twitter->get('search/tweets', ['q' => 'twitter']);
         $this->assertEquals('search/tweets', $this->twitter->getLastApiPath());
         $this->assertEquals(200, $this->twitter->getLastHttpCode());
         $this->assertObjectHasAttribute('statuses', $this->twitter->getLastBody());
@@ -251,6 +251,6 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
         $this->twitter->resetLastResponse();
         $this->assertEquals('', $this->twitter->getLastApiPath());
         $this->assertEquals(0, $this->twitter->getLastHttpCode());
-        $this->assertEquals(array(), $this->twitter->getLastBody());
+        $this->assertEquals([], $this->twitter->getLastBody());
     }
 }

--- a/tests/Util/JsonDecoderTest.php
+++ b/tests/Util/JsonDecoderTest.php
@@ -16,24 +16,24 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
 
     public function jsonProvider()
     {
-        return array(
-            array('[]', true, array()),
-            array('[1,2,3]', true, array(1, 2, 3)),
-            array('[{"id": 556179961825226750}]', true, array(array('id' => 556179961825226750))),
-            array('[]', false, array()),
-            array('[1,2,3]', false, array(1, 2, 3)),
-            array(
+        return [
+            ['[]', true, []],
+            ['[1,2,3]', true, [1, 2, 3]],
+            ['[{"id": 556179961825226750}]', true, [['id' => 556179961825226750]]],
+            ['[]', false, []],
+            ['[1,2,3]', false, [1, 2, 3]],
+            [
                 '[{"id": 556179961825226750}]',
                 false,
-                array(
+                [
                     $this->getClass(function ($object) {
                         $object->id = 556179961825226750;
                         return $object;
                     })
-                )
-            ),
+                ]
+            ],
 
-        );
+        ];
     }
 
     /**


### PR DESCRIPTION
Code improvement using php-cs-fixer as:

    php php-cs-fixer fix --rules='{"array_syntax": {"syntax": "short"}}' twitteroauth

Since you are using only supported versions of PHP it makes sense use the new features and syntax which are more quick to write and improve legilibity for array config uses.