### PR TITLE
Added Short term fix enabling developer to provide base64 encoded data to the upload system

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -262,7 +262,7 @@ class TwitterOAuth extends Config
 		}else{
 			$base = base64_encode($parameters['media']);
 		}
-		unset $parameters['media'];
+		unset($parameters['media']);
 		
         $parameters['media_data'] = $base;
         return $this->http('POST', self::UPLOAD_HOST, $path, $parameters);

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -17,7 +17,7 @@ class TwitterOAuth extends Config
 {
     const API_VERSION = '1.1';
     const API_HOST = 'https://api.twitter.com';
-    const UPLOAD_HOST = 'https://upload.twitter.com/1.1/';
+    const UPLOAD_HOST = 'https://upload.twitter.com';
     const UPLOAD_CHUNK = 40960; // 1024 * 40
 
     /** @var Response details about the result of the last request */

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -238,17 +238,29 @@ class TwitterOAuth extends Config
 
     /**
      * Private method to upload media (not chunked) to upload.twitter.com.
+	 * UPDATE per https://dev.twitter.com/rest/reference/post/media/upload to use media_data for base64 encoded filesize
+	 * and check if parameter is a file path if not assume it's base64_encode already
      *
      * @param string $path
      * @param array  $parameters
      *
      * @return array|object
+	 * @updatedby Martin Barker 
+	 * @updated 3rd March 2017
      */
     private function uploadMediaNotChunked($path, array $parameters)
     {
-        $file = file_get_contents($parameters['media']);
-        $base = base64_encode($file);
-        $parameters['media'] = $base;
+		
+		$base = "";
+		if(file_exists($parameters['media'])){
+			$file = file_get_contents($parameters['media']);
+			$base = base64_encode($file);
+		}else{
+			$base = $parameters['media'];
+		}
+		unset $parameters['media'];
+		
+        $parameters['media_data'] = $base;
         return $this->http('POST', self::UPLOAD_HOST, $path, $parameters);
     }
 

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -252,11 +252,15 @@ class TwitterOAuth extends Config
     {
 		
 		$base = "";
-		if(file_exists($parameters['media'])){
-			$file = file_get_contents($parameters['media']);
-			$base = base64_encode($file);
+		if(ctype_print($parameters['media'])){
+			if(file_exists($parameters['media'])){
+				$file = file_get_contents($parameters['media']);
+				$base = base64_encode($file);
+			}else{
+				$base = $parameters['media'];
+			}
 		}else{
-			$base = $parameters['media'];
+			$base = base64_encode($parameters['media']);
 		}
 		unset $parameters['media'];
 		

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -17,7 +17,7 @@ class TwitterOAuth extends Config
 {
     const API_VERSION = '1.1';
     const API_HOST = 'https://api.twitter.com';
-    const UPLOAD_HOST = 'https://upload.twitter.com';
+    const UPLOAD_HOST = 'https://upload.twitter.com/1.1/';
     const UPLOAD_CHUNK = 40960; // 1024 * 40
 
     /** @var Response details about the result of the last request */


### PR DESCRIPTION
Updated the method `TwitterOAuth::uploadMediaNotChunked` so that it uses the `media_data` parameter for Twitter when sending `base64_encoded` data to Twitter as per Twitters documentation, 

Also changed the method so it check if there is a string in contents of media if so it's more than likely a path or base64 encoded data. So check if it's a path to a file that exists if not assume it is base64 encoded data, if it is a path to a file that exists's as per original open file and `base64_encode` it. if it failed the string test it assumed to be binary data, base64 encode it and upload it to twitter.