### PR TITLE
Started working on a Retry Feature

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -13,7 +13,7 @@ class Config
     protected $timeout = 5;
     /** @var int how long to wait while connecting to the API */
     protected $connectionTimeout = 5;
-    /** @var int How many we retry request if we get 500's errors  */
+    /** @var int How many times we retry the request before throwing an exception */
     protected $maxRetries = 3;
     /** @var int Delay in seconds before we retry the request */
     protected $retriesDelay = 1;
@@ -54,8 +54,8 @@ class Config
     /**
      *  Set the number of times to retry on error and how long between each.
      *
-     * @param [type] $maxRetries   [description]
-     * @param [type] $retriesDelay [description]
+     * @param int $maxRetries
+     * @param int $retriesDelay
      */
     public function setRetries($maxRetries, $retriesDelay)
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,7 +13,7 @@ class Config
     protected $timeout = 5;
     /** @var int how long to wait while connecting to the API */
     protected $connectionTimeout = 5;
-    /** @var int How many times we retry the request before throwing an exception */
+    /** @var int How many times we retry request when API is down */
     protected $maxRetries = 3;
     /** @var int Delay in seconds before we retry the request */
     protected $retriesDelay = 1;

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,6 +13,13 @@ class Config
     protected $timeout = 5;
     /** @var int how long to wait while connecting to the API */
     protected $connectionTimeout = 5;
+    /** @var int How many times we retry the request before throwing an exception */
+    protected $maxRetries = 3;
+    /** @var int Delay in seconds before we retry the request */
+    protected $retriesDelay = 1;
+
+
+
     /**
      * Decode JSON Response as associative Array
      *
@@ -42,6 +49,18 @@ class Config
     {
         $this->connectionTimeout = (int)$connectionTimeout;
         $this->timeout = (int)$timeout;
+    }
+
+    /**
+     *  Set the number of times to retry on error and how long between each.
+     *
+     * @param [type] $maxRetries   [description]
+     * @param [type] $retriesDelay [description]
+     */
+    public function setRetries($maxRetries, $retriesDelay)
+    {
+        $this->maxRetries = (int)$maxRetries;
+        $this->retriesDelay = (int)$retriesDelay;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,7 +13,7 @@ class Config
     protected $timeout = 5;
     /** @var int how long to wait while connecting to the API */
     protected $connectionTimeout = 5;
-    /** @var int How many times we retry the request before throwing an exception */
+    /** @var int How many we retry request if we get 500's errors  */
     protected $maxRetries = 3;
     /** @var int Delay in seconds before we retry the request */
     protected $retriesDelay = 1;

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,7 +13,7 @@ class Config
     protected $timeout = 5;
     /** @var int how long to wait while connecting to the API */
     protected $connectionTimeout = 5;
-    /** @var int How many times we retry the request before throwing an exception */
+    /** @var int How many times we retry request when API is down */
     protected $maxRetries = 0;
     /** @var int Delay in seconds before we retry the request */
     protected $retriesDelay = 1;

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,8 +13,8 @@ class Config
     protected $timeout = 5;
     /** @var int how long to wait while connecting to the API */
     protected $connectionTimeout = 5;
-    /** @var int How many times we retry request when API is down */
-    protected $maxRetries = 3;
+    /** @var int How many times we retry the request before throwing an exception */
+    protected $maxRetries = 0;
     /** @var int Delay in seconds before we retry the request */
     protected $retriesDelay = 1;
 

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -364,11 +364,20 @@ class TwitterOAuth extends Config
             $this->response->setBody($response);
             $this->attempts++;
             // Retry up to our $maxRetries number if we get errors greater than 500 (over capacity etc)
-        } while ($this->maxRetries && ($this->attempts <= $this->maxRetries) && $this->getLastHttpCode() < 500);
+        } while ($this->requestsAvailable());
 
         return $response;
     }
 
+    /**
+     * Checks if we have to retry request if API is down.
+     *
+     * @return bool
+     */
+    private function requestsAvailable()
+    {
+        return ($this->maxRetries && ($this->attempts <= $this->maxRetries) && $this->getLastHttpCode() < 500);
+    }
 
     /**
      * Format and sign an OAuth / API request

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -103,6 +103,14 @@ class TwitterOAuth extends Config
     }
 
     /**
+     * Resets the attempts number.
+     */
+    public function resetAttemptsNumber()
+    {
+        $this->attempts = 0;
+    }
+
+    /**
      * Make URLs for user browser navigation.
      *
      * @param string $path
@@ -331,6 +339,8 @@ class TwitterOAuth extends Config
             $this->attempts++;
             // Retry up to our $maxRetries number if we get errors greater than 500 (over capacity etc)
         } while ($this->attempts <= $this->maxRetries && $this->getLastHttpCode() < 500);
+
+        $this->resetAttemptsNumber();
 
         return $response;
     }


### PR DESCRIPTION
Following my post #573, I tried with my little knowledge to incorporate a retry feature here. It keeps trying to execute a request (up to our $maxRetries number) in case we're getting status code equal or greater than 500. On Twitter it basically means over capacity, internal error etc..

I added a `setRetries()` function to set up $maxRetries & $retriesDelay. By default, $maxRetries is set at 3, and the delay ($retriesDelay) to one second.
