### PR TITLE
Fix: only retry on errors equal or greater than 500

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -14,7 +14,7 @@ class Config
     /** @var int how long to wait while connecting to the API */
     protected $connectionTimeout = 5;
     /** @var int How many times we retry request when API is down */
-    protected $maxRetries = 0;
+    protected $maxRetries = 5;
     /** @var int Delay in seconds before we retry the request */
     protected $retriesDelay = 1;
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -14,7 +14,7 @@ class Config
     /** @var int how long to wait while connecting to the API */
     protected $connectionTimeout = 5;
     /** @var int How many times we retry request when API is down */
-    protected $maxRetries = 5;
+    protected $maxRetries = 0;
     /** @var int Delay in seconds before we retry the request */
     protected $retriesDelay = 1;
 

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -376,7 +376,7 @@ class TwitterOAuth extends Config
      */
     private function requestsAvailable()
     {
-        return ($this->maxRetries && ($this->attempts <= $this->maxRetries) && $this->getLastHttpCode() < 500);
+        return ($this->maxRetries && ($this->attempts <= $this->maxRetries) && $this->getLastHttpCode() >= 500);
     }
 
     /**


### PR DESCRIPTION
Sorry I messed up the while condition. The do-while loop should only happen again if:

1. retries are enabled ;
2. we didn't reach the max retries number ;
3. the last http code is equal or greater than 500 (instead of less than in my previous PR).

Regards