### PR TITLE
Upload Media Chunked file check for errors first

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -283,6 +283,11 @@ class TwitterOAuth extends Config
     private function uploadMediaChunked($path, array $parameters)
     {
         $init = $this->http('POST', self::UPLOAD_HOST, $path, $this->mediaInitParameters($parameters));
+        // If there are errors with the file, like gif or video requirements are not met
+        if (!isset($init->media_id_string)) {
+            // Return the object with the error from the API just like not chunked method
+            return $init;
+        }
         // Append
         $segmentIndex = 0;
         $media = fopen($parameters['media'], 'rb');


### PR DESCRIPTION
Before creating chunk upload, check if he media_id_string is set because if the file has errors, it won't be and just return the pure API response just like uploadMediaNotChunked() method

If errors occur with the file, there will be $init->errors array filled with all errors from the API.
No need to change the Tests