### PR TITLE
updating constructor to use set* functions for bearer and token

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -46,10 +46,10 @@ class TwitterOAuth extends Config
         $this->signatureMethod = new HmacSha1();
         $this->consumer = new Consumer($consumerKey, $consumerSecret);
         if (!empty($oauthToken) && !empty($oauthTokenSecret)) {
-            $this->token = new Token($oauthToken, $oauthTokenSecret);
+            $this->setOauthToken($oauthToken, $oauthTokenSecret);
         }
         if (empty($oauthToken) && !empty($oauthTokenSecret)) {
-            $this->bearer = $oauthTokenSecret;
+            $this->setBearer($oauthTokenSecret);
         }
     }
 
@@ -60,6 +60,16 @@ class TwitterOAuth extends Config
     public function setOauthToken($oauthToken, $oauthTokenSecret)
     {
         $this->token = new Token($oauthToken, $oauthTokenSecret);
+        $this->bearer = null;
+    }
+
+    /**
+     * @param string $oauthTokenSecret
+     */
+    public function setBearer($oauthTokenSecret)
+    {
+        $this->bearer = $oauthTokenSecret;
+        $this->token = null;
     }
 
     /**


### PR DESCRIPTION
This update makes the following changes:

* Updates `setToken` to also set the bearer member variable to `null`
* Creates a `setBearer` function that sets the bearer member variable to the value passed into the function and sets the token member variable to `null`
* Updates the constructor to call `setToken` and `setBearer` instead of setting the token and the bearer member variables directly

This update will facilitate use of the library for app-level authentication only; prior to this update, using app-level authentication would require authenticating and then re-instantiating the TwitterOAuth object to set the bearer member variable.