### PR TITLE
exception to media/upload GET request

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -201,12 +201,14 @@ class TwitterOAuth extends Config
      *
      * @param string $path
      * @param array  $parameters
+     * @param bool   $API_HOST
      *
      * @return array|object
      */
-    public function get($path, array $parameters = [])
+    public function get($path, array $parameters = [], $is_upload_host = false)
     {
-        return $this->http('GET', self::API_HOST, $path, $parameters);
+        $host = (! $is_upload_host) ? self::API_HOST : self::UPLOAD_HOST;
+        return $this->http('GET', $host, $path, $parameters);
     }
 
     /**

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -200,14 +200,14 @@ class TwitterOAuth extends Config
      * Make GET requests to the API.
      *
      * @param string $path
-     * @param array  $parameters
-     * @param bool   $API_HOST
+     * @param array $parameters
      *
      * @return array|object
      */
-    public function get($path, array $parameters = [], $is_upload_host = false)
+    public function get($path, array $parameters = [])
     {
-        $host = (! $is_upload_host) ? self::API_HOST : self::UPLOAD_HOST;
+        $host = ($path === 'media/upload') ? self::UPLOAD_HOST : self::API_HOST;
+
         return $this->http('GET', $host, $path, $parameters);
     }
 


### PR DESCRIPTION
When accessing media/upload and the HTTP VERB is GET, we need to use UPLOAD_HOST.