### PR TITLE
Throw exception when file not readable - #412

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -276,9 +276,11 @@ class TwitterOAuth extends Config
      */
     private function uploadMediaNotChunked($path, array $parameters)
     {
-        $file = file_get_contents($parameters['media']);
-        $base = base64_encode($file);
-        $parameters['media'] = $base;
+        if (! is_readable($parameters['media']) ||
+            ($file = file_get_contents($parameters['media'])) === false) {
+            throw new \InvalidArgumentException('You must supply a readable file');
+        }
+        $parameters['media'] = base64_encode($file);
         return $this->http('POST', self::UPLOAD_HOST, $path, $parameters);
     }
 

--- a/tests/TwitterOAuthTest.php
+++ b/tests/TwitterOAuthTest.php
@@ -202,6 +202,14 @@ class TwitterOAuthTest extends \PHPUnit_Framework_TestCase
         return $result;
     }
 
+    public function testPostStatusUpdateWithInvalidMediaThrowsException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $file_path = __DIR__ . '/12345678900987654321.jpg';
+        $this->assertFalse(\is_readable($file_path));
+        $result = $this->twitter->upload('media/upload', ['media' => $file_path]);
+    }
+
     public function testPostStatusesUpdateWithMediaChunked()
     {
         $this->twitter->setTimeouts(60, 30);


### PR DESCRIPTION
`is_readable` catches most cases of files not being readable.

Not 100% sure when `file_get_contents` returns false. It seems to be happening when `php.ini` is configured with `allow_url_fopen = Off`. 

Difficult to integrate in a test, any ideas? 