### PR TITLE
Add method for making GET requests to the upload API

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -267,6 +267,19 @@ class TwitterOAuth extends Config
     }
 
     /**
+     * Make GET requests to the Upload API
+     *
+     * @param string $path
+     * @param array $parameters
+     *
+     * @return array|object
+     */
+    public function getUpload($path, array $parameters = [])
+    {
+        return $this->http('GET', self::UPLOAD_HOST, $path, $parameters);
+    }
+
+    /**
      * Private method to upload media (not chunked) to upload.twitter.com.
      *
      * @param string $path


### PR DESCRIPTION
It looks like this issue has come up before, as outlined here: https://github.com/abraham/twitteroauth/issues/554 .  There is currently no direct method of making anything other than POST requests to the upload base API.  This PR simply adds a method that allows GET requests to that API while still allowing for the flexibility provided by passing the path and parameter resources.

Here's example usage:
``` 
...         
$tries = 0;
$maxTries = 5;
$pending = true;
while ($tries < $maxTries && $pending) {
    $statusResponse = $twitter->getUpload('media/upload', [
        'media_id' => $mediaId,
        'command' => 'STATUS',
    ]);
    $processingInfo = $statusResponse->processing_info;

    if (!$processingInfo) {
        throw new \Exception('Could not get status of uploaded video');
    }
    switch ($processingInfo->state) {
        case 'pending':
            $tries++;
            $checkAfterSecs = $processingInfo->check_after_secs ?: 5;
            sleep($checkAfterSecs);
            break;
        case 'succeeded':
            $pending = false;
            break;
        case 'failed':
            throw new \Exception('Could not upload video: ' . $processingInfo->error->message);
            break;
    }
}
if ($pending) {
    throw new \Exception('Video upload timed out');
}
```