### PR TITLE
Requests with JSON data

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -10,6 +10,7 @@ class Request
     protected $parameters;
     protected $httpMethod;
     protected $httpUrl;
+    protected $json;
     public static $version = '1.0';
 
     /**
@@ -43,7 +44,8 @@ class Request
         Token $token = null,
         $httpMethod,
         $httpUrl,
-        array $parameters = []
+        array $parameters = [],
+        $json = false
     ) {
         $defaults = [
             "oauth_version" => Request::$version,
@@ -55,7 +57,12 @@ class Request
             $defaults['oauth_token'] = $token->key;
         }
 
-        $parameters = array_merge($defaults, $parameters);
+        //The json payload is not included in the signature on json requests, therefore it shouldn't be included in the parameters array
+        if($json) {
+            $parameters = $defaults;
+        } else {
+            $parameters = array_merge($defaults, $parameters);
+        }
 
         return new Request($httpMethod, $httpUrl, $parameters);
     }

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -214,12 +214,13 @@ class TwitterOAuth extends Config
      *
      * @param string $path
      * @param array  $parameters
+     * @param bool   $json
      *
      * @return array|object
      */
-    public function post($path, array $parameters = [])
+    public function post($path, array $parameters = [], $json = false)
     {
-        return $this->http('POST', self::API_HOST, $path, $parameters);
+        return $this->http('POST', self::API_HOST, $path, $parameters, $json);
     }
 
     /**
@@ -243,9 +244,9 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function put($path, array $parameters = [])
+    public function put($path, array $parameters = [], $json = false)
     {
-        return $this->http('PUT', self::API_HOST, $path, $parameters);
+        return $this->http('PUT', self::API_HOST, $path, $parameters, $json);
     }
 
     /**
@@ -342,16 +343,17 @@ class TwitterOAuth extends Config
      * @param string $host
      * @param string $path
      * @param array  $parameters
+     * @param bool   $json
      *
      * @return array|object
      */
-    private function http($method, $host, $path, array $parameters)
+    private function http($method, $host, $path, array $parameters, $json = false)
     {
         $this->resetLastResponse();
         $this->resetAttemptsNumber();
         $url = sprintf('%s/%s/%s.json', $host, self::API_VERSION, $path);
         $this->response->setApiPath($path);
-        return $this->makeRequests($url, $method, $parameters);
+        return $this->makeRequests($url, $method, $parameters, $json);
     }
 
     /**
@@ -362,14 +364,15 @@ class TwitterOAuth extends Config
      * @param string $url
      * @param string $method
      * @param array  $parameters
+     * @param bool   $json
      *
      * @return array|object
      */
-    private function makeRequests($url, $method, array $parameters)
+    private function makeRequests($url, $method, array $parameters, $json = false)
     {
         do {
             $this->sleepIfNeeded();
-            $result = $this->oAuthRequest($url, $method, $parameters);
+            $result = $this->oAuthRequest($url, $method, $parameters, $json);
             $response = JsonDecoder::decode($result, $this->decodeJsonAsArray);
             $this->response->setBody($response);
             $this->attempts++;
@@ -395,13 +398,14 @@ class TwitterOAuth extends Config
      * @param string $url
      * @param string $method
      * @param array  $parameters
+     * @param bool   $json
      *
      * @return string
      * @throws TwitterOAuthException
      */
-    private function oAuthRequest($url, $method, array $parameters)
+    private function oAuthRequest($url, $method, array $parameters, $json = false)
     {
-        $request = Request::fromConsumerAndToken($this->consumer, $this->token, $method, $url, $parameters);
+        $request = Request::fromConsumerAndToken($this->consumer, $this->token, $method, $url, $parameters, $json);
         if (array_key_exists('oauth_callback', $parameters)) {
             // Twitter doesn't like oauth_callback as a parameter.
             unset($parameters['oauth_callback']);
@@ -417,7 +421,7 @@ class TwitterOAuth extends Config
         } else {
             $authorization = 'Authorization: Bearer ' . $this->bearer;
         }
-        return $this->request($request->getNormalizedHttpUrl(), $method, $authorization, $parameters);
+        return $this->request($request->getNormalizedHttpUrl(), $method, $authorization, $parameters, $json);
     }
 
     /**
@@ -464,22 +468,30 @@ class TwitterOAuth extends Config
      * @param string $method
      * @param string $authorization
      * @param array $postfields
+     * @param bool $json
      *
      * @return string
      * @throws TwitterOAuthException
      */
-    private function request($url, $method, $authorization, array $postfields)
+    private function request($url, $method, $authorization, array $postfields, $json = false)
     {
         $options = $this->curlOptions();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_HTTPHEADER] = ['Accept: application/json', $authorization, 'Expect:'];
+        if($json) {
+            $options[CURLOPT_HTTPHEADER][] = 'Content-type: application/json';
+        }
 
         switch ($method) {
             case 'GET':
                 break;
             case 'POST':
                 $options[CURLOPT_POST] = true;
-                $options[CURLOPT_POSTFIELDS] = Util::buildHttpQuery($postfields);
+                if($json) {
+                    $options[CURLOPT_POSTFIELDS] = json_encode($postfields);
+                } else {
+                    $options[CURLOPT_POSTFIELDS] = Util::buildHttpQuery($postfields);
+                }
                 break;
             case 'DELETE':
                 $options[CURLOPT_CUSTOMREQUEST] = 'DELETE';

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -244,7 +244,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function put($path, array $parameters = [], $json = false)
+    public function put($path, array $parameters = [])
     {
         return $this->http('PUT', self::API_HOST, $path, $parameters, $json);
     }


### PR DESCRIPTION
Some twitter APIs required data to be sent in JSON format instead of the regular form-data format. There were no support for those requests in the library. 

I added support for JSON post requests to use in one of my projects and I'm creating this pull request in the hopes that it get included in the default library.

The post method now has a third parameter which is a boolean that defaults to false. If true, the parameters array will be treated as a json associative array. It will add correct content-type header, generate the correct authentication signature, and encode the parameters array to json format and send as the request body.

Example:
```php

$t = new TwitterOAuth(env('TWITTER_APP_CONSUMER_KEY'), env('TWITTER_APP_CONSUMER_SECRET'), env('TWITTER_APP_ACCESS_TOKEN'), env('TWITTER_APP_ACCESS_TOKEN_SECRET'));

$jsonArray = [ 
    'event' => [
        'type' => 'message_create',
        'message_create' => [
            'target' => [
                'recipient_id' => 'XXXXXX'
            ], 
            'message_data' => [
                'text' => 'Hello World!'
            ]
        ]
    ]
];

$t->post('direct_messages/events/new', $jsonArray, true);
```