### PR TITLE
#625 added method to check upload status

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -267,6 +267,21 @@ class TwitterOAuth extends Config
     }
 
     /**
+     * Progression of media upload
+     *
+     * @param string $media_id
+     *
+     * @return array|object
+     */
+    public function mediaStatus($media_id)
+    {
+        return $this->http('GET', self::UPLOAD_HOST, 'media/upload', [
+            'command' => 'STATUS',
+            'media_id' => $media_id
+        ]);
+    }
+
+    /**
      * Private method to upload media (not chunked) to upload.twitter.com.
      *
      * @param string $path


### PR DESCRIPTION
fixes issue #625 

Checking the status is essential when uploading media. Only media with status succeded can be tweeted. e.g.

```
// do upload
// wait for video post processing
            $limit = 0;
            do{
                $status = $this->handle->mediaStatus($media->media_id_string);
                sleep(5);
                $limit++;
            }while($status->processing_info->state !== 'succeeded' && $limit <= 10);
// do tweet

```