### PR TITLE
Remove is_readable from media upload check to allow for url

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -292,12 +292,13 @@ class TwitterOAuth extends Config
      */
     private function uploadMediaNotChunked($path, array $parameters)
     {
-        if (! is_readable($parameters['media']) ||
-            ($file = file_get_contents($parameters['media'])) === false) {
+        if (($file = file_get_contents($parameters['media'])) === false) {
             throw new \InvalidArgumentException('You must supply a readable file');
         }
+        
         $parameters['media'] = base64_encode($file);
-        return $this->http('POST', self::UPLOAD_HOST, $path, $parameters, false);
+        
+        return $this->http('POST', self::UPLOAD_HOST, $path, $parameters, false); 
     }
 
     /**


### PR DESCRIPTION
If you give that function "uploadMediaNotChunked" a url,  is_readable is returning false as file_get_contents would work. 
But since its a OR check is_readable is already true and it throws an exception even though file_get_contents would work.

Removing is_readable from the check makes sure the file can be read has file contents returns false if not readable anyway. So is_readable is redundant and like this it would allow for urls as media source.

Hope that makes sense.