### PR TITLE
developer specified parameters take precedence

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -344,7 +344,7 @@ class TwitterOAuth extends Config
         $return = [
             'command' => 'INIT',
             'media_type' => $parameters['media_type'],
-            'total_bytes' => filesize($parameters['media'])
+            'total_bytes' => isset($parameters['total_bytes']) ? $parameters['total_bytes'] : filesize($parameters['media'])
         ];
         if (isset($parameters['additional_owners'])) {
             $return['additional_owners'] = $parameters['additional_owners'];


### PR DESCRIPTION
When generating the media upload init parameters, allow the
developer to specify the `total_bytes` parameter in order
to avoid the call to `filesize` which relies on a system
method call which fails on remote files.

This allows remote files to be uploaded to Twitter without
first needing to be downloaded to a local file.

Resolves #706