### PR TITLE
Declare strict types and enforce them, fixes #679

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 dist: trusty
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
   - '7.2'
   - nightly

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Abraham\TwitterOAuth;
 
@@ -43,10 +44,10 @@ class Config
      * @param int $connectionTimeout
      * @param int $timeout
      */
-    public function setTimeouts($connectionTimeout, $timeout)
+    public function setTimeouts(int $connectionTimeout, int $timeout): void
     {
-        $this->connectionTimeout = (int)$connectionTimeout;
-        $this->timeout = (int)$timeout;
+        $this->connectionTimeout = $connectionTimeout;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -55,32 +56,32 @@ class Config
      * @param int $maxRetries
      * @param int $retriesDelay
      */
-    public function setRetries($maxRetries, $retriesDelay)
+    public function setRetries(int $maxRetries, int $retriesDelay): void
     {
-        $this->maxRetries = (int)$maxRetries;
-        $this->retriesDelay = (int)$retriesDelay;
+        $this->maxRetries = $maxRetries;
+        $this->retriesDelay = $retriesDelay;
     }
 
     /**
      * @param bool $value
      */
-    public function setDecodeJsonAsArray($value)
+    public function setDecodeJsonAsArray(bool $value): void
     {
-        $this->decodeJsonAsArray = (bool)$value;
+        $this->decodeJsonAsArray = $value;
     }
 
     /**
      * @param string $userAgent
      */
-    public function setUserAgent($userAgent)
+    public function setUserAgent(string $userAgent): void
     {
-        $this->userAgent = (string)$userAgent;
+        $this->userAgent = $userAgent;
     }
 
     /**
      * @param array $proxy
      */
-    public function setProxy(array $proxy)
+    public function setProxy(array $proxy): void
     {
         $this->proxy = $proxy;
     }
@@ -90,9 +91,9 @@ class Config
      *
      * @param boolean $gzipEncoding
      */
-    public function setGzipEncoding($gzipEncoding)
+    public function setGzipEncoding(bool $gzipEncoding): void
     {
-        $this->gzipEncoding = (bool)$gzipEncoding;
+        $this->gzipEncoding = $gzipEncoding;
     }
 
     /**
@@ -100,8 +101,8 @@ class Config
      *
      * @param int $value
      */
-    public function setChunkSize($value)
+    public function setChunkSize(int $value): void
     {
-        $this->chunkSize = (int)$value;
+        $this->chunkSize = $value;
     }
 }

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * The MIT License
  * Copyright (c) 2007 Andy Smith
@@ -15,11 +17,11 @@ class Consumer
     public $callbackUrl;
 
     /**
-     * @param string $key
-     * @param string $secret
+     * @param string|null $key
+     * @param string|null $secret
      * @param null $callbackUrl
      */
-    public function __construct($key, $secret, $callbackUrl = null)
+    public function __construct(?string $key, ?string $secret, ?string $callbackUrl = null)
     {
         $this->key = $key;
         $this->secret = $secret;

--- a/src/HmacSha1.php
+++ b/src/HmacSha1.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * The MIT License
  * Copyright (c) 2007 Andy Smith
@@ -25,7 +27,7 @@ class HmacSha1 extends SignatureMethod
     /**
      * {@inheritDoc}
      */
-    public function buildSignature(Request $request, Consumer $consumer, Token $token = null)
+    public function buildSignature(Request $request, Consumer $consumer, Token $token = null): string
     {
         $signatureBase = $request->getSignatureBaseString();
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * The MIT License
  * Copyright (c) 2007 Andy Smith
@@ -20,7 +22,7 @@ class Request
      * @param string     $httpUrl
      * @param array|null $parameters
      */
-    public function __construct($httpMethod, $httpUrl, array $parameters = [])
+    public function __construct(string $httpMethod, string $httpUrl, ?array $parameters = [])
     {
         $parameters = array_merge(Util::parseParameters(parse_url($httpUrl, PHP_URL_QUERY)), $parameters);
         $this->parameters = $parameters;
@@ -42,8 +44,8 @@ class Request
     public static function fromConsumerAndToken(
         Consumer $consumer,
         Token $token = null,
-        $httpMethod,
-        $httpUrl,
+        string $httpMethod,
+        string $httpUrl,
         array $parameters = [],
         $json = false
     ) {
@@ -72,7 +74,7 @@ class Request
      * @param string $name
      * @param string $value
      */
-    public function setParameter($name, $value)
+    public function setParameter(string $name, string $value)
     {
         $this->parameters[$name] = $value;
     }
@@ -82,7 +84,7 @@ class Request
      *
      * @return string|null
      */
-    public function getParameter($name)
+    public function getParameter(string $name): ?string
     {
         return isset($this->parameters[$name]) ? $this->parameters[$name] : null;
     }
@@ -90,7 +92,7 @@ class Request
     /**
      * @return array
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         return $this->parameters;
     }
@@ -98,7 +100,7 @@ class Request
     /**
      * @param $name
      */
-    public function removeParameter($name)
+    public function removeParameter(string $name): void
     {
         unset($this->parameters[$name]);
     }
@@ -108,7 +110,7 @@ class Request
      *
      * @return string
      */
-    public function getSignableParameters()
+    public function getSignableParameters(): string
     {
         // Grab all parameters
         $params = $this->parameters;
@@ -131,7 +133,7 @@ class Request
      *
      * @return string
      */
-    public function getSignatureBaseString()
+    public function getSignatureBaseString(): string
     {
         $parts = [
             $this->getNormalizedHttpMethod(),
@@ -149,7 +151,7 @@ class Request
      *
      * @return string
      */
-    public function getNormalizedHttpMethod()
+    public function getNormalizedHttpMethod(): string
     {
         return strtoupper($this->httpMethod);
     }
@@ -160,7 +162,7 @@ class Request
      *
      * @return string
      */
-    public function getNormalizedHttpUrl()
+    public function getNormalizedHttpUrl(): string
     {
         $parts = parse_url($this->httpUrl);
 
@@ -176,7 +178,7 @@ class Request
      *
      * @return string
      */
-    public function toUrl()
+    public function toUrl(): string
     {
         $postData = $this->toPostdata();
         $out = $this->getNormalizedHttpUrl();
@@ -191,7 +193,7 @@ class Request
      *
      * @return string
      */
-    public function toPostdata()
+    public function toPostdata(): string
     {
         return Util::buildHttpQuery($this->parameters);
     }
@@ -202,7 +204,7 @@ class Request
      * @return string
      * @throws TwitterOAuthException
      */
-    public function toHeader()
+    public function toHeader(): string
     {
         $first = true;
         $out = 'Authorization: OAuth';
@@ -223,7 +225,7 @@ class Request
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toUrl();
     }
@@ -247,7 +249,7 @@ class Request
      *
      * @return string
      */
-    public function buildSignature(SignatureMethod $signatureMethod, Consumer $consumer, Token $token = null)
+    public function buildSignature(SignatureMethod $signatureMethod, Consumer $consumer, Token $token = null): string
     {
         return $signatureMethod->buildSignature($this, $consumer, $token);
     }
@@ -255,7 +257,7 @@ class Request
     /**
      * @return string
      */
-    public static function generateNonce()
+    public static function generateNonce(): string
     {
         return md5(microtime() . mt_rand());
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Abraham\TwitterOAuth;
 
@@ -23,7 +24,7 @@ class Response
     /**
      * @param string $apiPath
      */
-    public function setApiPath($apiPath)
+    public function setApiPath(string $apiPath): void
     {
         $this->apiPath = $apiPath;
     }
@@ -31,7 +32,7 @@ class Response
     /**
      * @return string|null
      */
-    public function getApiPath()
+    public function getApiPath(): ?string
     {
         return $this->apiPath;
     }
@@ -55,7 +56,7 @@ class Response
     /**
      * @param int $httpCode
      */
-    public function setHttpCode($httpCode)
+    public function setHttpCode(int $httpCode): void
     {
         $this->httpCode = $httpCode;
     }
@@ -63,7 +64,7 @@ class Response
     /**
      * @return int
      */
-    public function getHttpCode()
+    public function getHttpCode(): int
     {
         return $this->httpCode;
     }
@@ -71,7 +72,7 @@ class Response
     /**
      * @param array $headers
      */
-    public function setHeaders(array $headers)
+    public function setHeaders(array $headers): void
     {
         foreach ($headers as $key => $value) {
             if (substr($key, 0, 1) == 'x') {
@@ -84,7 +85,7 @@ class Response
     /**
      * @return array
      */
-    public function getsHeaders()
+    public function getsHeaders(): array
     {
         return $this->headers;
     }
@@ -92,7 +93,7 @@ class Response
     /**
      * @param array $xHeaders
      */
-    public function setXHeaders(array $xHeaders = [])
+    public function setXHeaders(array $xHeaders = []): void
     {
         $this->xHeaders = $xHeaders;
     }
@@ -100,7 +101,7 @@ class Response
     /**
      * @return array
      */
-    public function getXHeaders()
+    public function getXHeaders(): array
     {
         return $this->xHeaders;
     }

--- a/src/SignatureMethod.php
+++ b/src/SignatureMethod.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * The MIT License
  * Copyright (c) 2007 Andy Smith
@@ -42,7 +44,7 @@ abstract class SignatureMethod
      *
      * @return bool
      */
-    public function checkSignature(Request $request, Consumer $consumer, Token $token, $signature)
+    public function checkSignature(Request $request, Consumer $consumer, Token $token, string $signature): bool
     {
         $built = $this->buildSignature($request, $consumer, $token);
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * The MIT License
  * Copyright (c) 2007 Andy Smith
@@ -16,7 +18,7 @@ class Token
      * @param string $key    The OAuth Token
      * @param string $secret The OAuth Token Secret
      */
-    public function __construct($key, $secret)
+    public function __construct(?string $key, ?string $secret)
     {
         $this->key = $key;
         $this->secret = $secret;
@@ -28,7 +30,7 @@ class Token
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return sprintf(
             "oauth_token=%s&oauth_token_secret=%s",

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * The most popular PHP library for use with the Twitter OAuth REST API.
  *
@@ -40,8 +42,12 @@ class TwitterOAuth extends Config
      * @param string|null $oauthToken       The Client Token (optional)
      * @param string|null $oauthTokenSecret The Client Token Secret (optional)
      */
-    public function __construct($consumerKey, $consumerSecret, $oauthToken = null, $oauthTokenSecret = null)
-    {
+    public function __construct(
+        string $consumerKey,
+        string $consumerSecret,
+        ?string $oauthToken = null,
+        ?string $oauthTokenSecret = null
+    ) {
         $this->resetLastResponse();
         $this->signatureMethod = new HmacSha1();
         $this->consumer = new Consumer($consumerKey, $consumerSecret);
@@ -57,7 +63,7 @@ class TwitterOAuth extends Config
      * @param string $oauthToken
      * @param string $oauthTokenSecret
      */
-    public function setOauthToken($oauthToken, $oauthTokenSecret)
+    public function setOauthToken(string $oauthToken, string $oauthTokenSecret): void
     {
         $this->token = new Token($oauthToken, $oauthTokenSecret);
         $this->bearer = null;
@@ -66,7 +72,7 @@ class TwitterOAuth extends Config
     /**
      * @param string $oauthTokenSecret
      */
-    public function setBearer($oauthTokenSecret)
+    public function setBearer(string $oauthTokenSecret): void
     {
         $this->bearer = $oauthTokenSecret;
         $this->token = null;
@@ -75,7 +81,7 @@ class TwitterOAuth extends Config
     /**
      * @return string|null
      */
-    public function getLastApiPath()
+    public function getLastApiPath(): ?string
     {
         return $this->response->getApiPath();
     }
@@ -83,7 +89,7 @@ class TwitterOAuth extends Config
     /**
      * @return int
      */
-    public function getLastHttpCode()
+    public function getLastHttpCode(): int
     {
         return $this->response->getHttpCode();
     }
@@ -91,7 +97,7 @@ class TwitterOAuth extends Config
     /**
      * @return array
      */
-    public function getLastXHeaders()
+    public function getLastXHeaders(): array
     {
         return $this->response->getXHeaders();
     }
@@ -107,7 +113,7 @@ class TwitterOAuth extends Config
     /**
      * Resets the last response cache.
      */
-    public function resetLastResponse()
+    public function resetLastResponse(): void
     {
         $this->response = new Response();
     }
@@ -115,7 +121,7 @@ class TwitterOAuth extends Config
     /**
      * Resets the attempts number.
      */
-    private function resetAttemptsNumber()
+    private function resetAttemptsNumber(): void
     {
         $this->attempts = 0;
     }
@@ -123,7 +129,7 @@ class TwitterOAuth extends Config
     /**
      * Delays the retries when they're activated.
      */
-    private function sleepIfNeeded()
+    private function sleepIfNeeded(): void
     {
         if ($this->maxRetries && $this->attempts) {
             sleep($this->retriesDelay);
@@ -139,7 +145,7 @@ class TwitterOAuth extends Config
      *
      * @return string
      */
-    public function url($path, array $parameters)
+    public function url(string $path, array $parameters): string
     {
         $this->resetLastResponse();
         $this->response->setApiPath($path);
@@ -156,7 +162,7 @@ class TwitterOAuth extends Config
      * @return array
      * @throws TwitterOAuthException
      */
-    public function oauth($path, array $parameters = [])
+    public function oauth(string $path, array $parameters = []): array
     {
         $response = [];
         $this->resetLastResponse();
@@ -182,7 +188,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function oauth2($path, array $parameters = [])
+    public function oauth2(string $path, array $parameters = [])
     {
         $method = 'POST';
         $this->resetLastResponse();
@@ -204,7 +210,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function get($path, array $parameters = [])
+    public function get(string $path, array $parameters = [])
     {
         return $this->http('GET', self::API_HOST, $path, $parameters, false);
     }
@@ -218,7 +224,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function post($path, array $parameters = [], $json = false)
+    public function post(string $path, array $parameters = [], bool $json = false)
     {
         return $this->http('POST', self::API_HOST, $path, $parameters, $json);
     }
@@ -231,7 +237,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function delete($path, array $parameters = [])
+    public function delete(string $path, array $parameters = [])
     {
         return $this->http('DELETE', self::API_HOST, $path, $parameters, false);
     }
@@ -244,7 +250,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function put($path, array $parameters = [])
+    public function put(string $path, array $parameters = [])
     {
         return $this->http('PUT', self::API_HOST, $path, $parameters, false);
     }
@@ -258,7 +264,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function upload($path, array $parameters = [], $chunked = false)
+    public function upload(string $path, array $parameters = [], bool $chunked = false)
     {
         if ($chunked) {
             return $this->uploadMediaChunked($path, $parameters);
@@ -274,7 +280,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function mediaStatus($media_id)
+    public function mediaStatus(string $media_id)
     {
         return $this->http('GET', self::UPLOAD_HOST, 'media/upload', [
             'command' => 'STATUS',
@@ -290,7 +296,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    private function uploadMediaNotChunked($path, array $parameters)
+    private function uploadMediaNotChunked(string $path, array $parameters)
     {
         if (! is_readable($parameters['media']) ||
             ($file = file_get_contents($parameters['media'])) === false) {
@@ -308,7 +314,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    private function uploadMediaChunked($path, array $parameters)
+    private function uploadMediaChunked(string $path, array $parameters)
     {
         $init = $this->http('POST', self::UPLOAD_HOST, $path, $this->mediaInitParameters($parameters), false);
         // Append
@@ -339,7 +345,7 @@ class TwitterOAuth extends Config
      *
      * @return array
      */
-    private function mediaInitParameters(array $parameters)
+    private function mediaInitParameters(array $parameters): array
     {
         $return = [
             'command' => 'INIT',
@@ -382,7 +388,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    private function http($method, $host, $path, array $parameters, $json)
+    private function http(string $method, string $host, string $path, array $parameters, bool $json)
     {
         $this->resetLastResponse();
         $this->resetAttemptsNumber();
@@ -406,7 +412,7 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    private function makeRequests($url, $method, array $parameters, $json)
+    private function makeRequests(string $url, string $method, array $parameters, bool $json)
     {
         do {
             $this->sleepIfNeeded();
@@ -425,7 +431,7 @@ class TwitterOAuth extends Config
      *
      * @return bool
      */
-    private function requestsAvailable()
+    private function requestsAvailable(): bool
     {
         return ($this->maxRetries && ($this->attempts <= $this->maxRetries) && $this->getLastHttpCode() >= 500);
     }
@@ -441,7 +447,7 @@ class TwitterOAuth extends Config
      * @return string
      * @throws TwitterOAuthException
      */
-    private function oAuthRequest($url, $method, array $parameters, $json = false)
+    private function oAuthRequest(string $url, string $method, array $parameters, bool $json = false)
     {
         $request = Request::fromConsumerAndToken($this->consumer, $this->token, $method, $url, $parameters, $json);
         if (array_key_exists('oauth_callback', $parameters)) {
@@ -467,7 +473,7 @@ class TwitterOAuth extends Config
      *
      * @return array
      */
-    private function curlOptions()
+    private function curlOptions(): array
     {
         $options = [
             // CURLOPT_VERBOSE => true,
@@ -511,8 +517,13 @@ class TwitterOAuth extends Config
      * @return string
      * @throws TwitterOAuthException
      */
-    private function request($url, $method, $authorization, array $postfields, $json = false)
-    {
+    private function request(
+        string $url,
+        string $method,
+        string $authorization,
+        array $postfields,
+        bool $json = false
+    ): string {
         $options = $this->curlOptions();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_HTTPHEADER] = ['Accept: application/json', $authorization, 'Expect:'];
@@ -569,7 +580,7 @@ class TwitterOAuth extends Config
      *
      * @return array
      */
-    private function parseHeaders($header)
+    private function parseHeaders(string $header): array
     {
         $headers = [];
         foreach (explode("\r\n", $header) as $line) {
@@ -589,7 +600,7 @@ class TwitterOAuth extends Config
      *
      * @return string
      */
-    private function encodeAppAuthorization(Consumer $consumer)
+    private function encodeAppAuthorization(Consumer $consumer): string
     {
         $key = rawurlencode($consumer->key);
         $secret = rawurlencode($consumer->secret);
@@ -601,7 +612,7 @@ class TwitterOAuth extends Config
      *
      * @return boolean
      */
-    private function pharRunning()
+    private function pharRunning(): bool
     {
         return class_exists('Phar') && \Phar::running(false) !== '';
     }
@@ -611,7 +622,7 @@ class TwitterOAuth extends Config
      *
      * @return boolean
      */
-    private function useCAFile()
+    private function useCAFile(): bool
     {
         /* Use CACert file when not in a PHAR file. */
         return !$this->pharRunning();

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * The MIT License
  * Copyright (c) 2007 Andy Smith
@@ -18,7 +20,7 @@ class Util
         if (is_array($input)) {
             $output = array_map([__NAMESPACE__ . '\Util', 'urlencodeRfc3986'], $input);
         } elseif (is_scalar($input)) {
-            $output = rawurlencode($input);
+            $output = rawurlencode((string) $input);
         }
         return $output;
     }
@@ -28,7 +30,7 @@ class Util
      *
      * @return string
      */
-    public static function urldecodeRfc3986($string)
+    public static function urldecodeRfc3986($string): string
     {
         return urldecode($string);
     }
@@ -42,7 +44,7 @@ class Util
      *
      * @return array
      */
-    public static function parseParameters($input)
+    public static function parseParameters($input): array
     {
         if (!is_string($input)) {
             return [];
@@ -79,7 +81,7 @@ class Util
      *
      * @return string
      */
-    public static function buildHttpQuery(array $params)
+    public static function buildHttpQuery(array $params): string
     {
         if (empty($params)) {
             return '';

--- a/src/Util/JsonDecoder.php
+++ b/src/Util/JsonDecoder.php
@@ -15,7 +15,7 @@ class JsonDecoder
      *
      * @return array|object
      */
-    public static function decode($string, $asArray)
+    public static function decode(string $string, bool $asArray)
     {
         if (version_compare(PHP_VERSION, '5.4.0', '>=') && !(defined('JSON_C_VERSION') && PHP_INT_SIZE > 4)) {
             return json_decode($string, $asArray, 512, JSON_BIGINT_AS_STRING);


### PR DESCRIPTION
Here I declare strict types and also enforce them. It fixes #679 and helps with #678 

Things to consider:
* Some functions take several types of params (e.g array and objects). I think we can try to reduce them to just one. I did not set a type for those params. 
* Some functions return several types of params (e.g array and objects). I think we can we just one as well. I dislike the idea that sometimes it returns an object and sometimes an array, and this has broken my code sometimes. We can open a separate issue for these.

Hope this contribution is useful :smile: 