### PR TITLE
Allow more URL wrappers for media upload

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -292,8 +292,7 @@ class TwitterOAuth extends Config
      */
     private function uploadMediaNotChunked($path, array $parameters)
     {
-        if (! is_readable($parameters['media']) ||
-            ($file = file_get_contents($parameters['media'])) === false) {
+        if (($file = file_get_contents($parameters['media'])) === false) {
             throw new \InvalidArgumentException('You must supply a readable file');
         }
         $parameters['media'] = base64_encode($file);

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -292,7 +292,7 @@ class TwitterOAuth extends Config
      */
     private function uploadMediaNotChunked($path, array $parameters)
     {
-        if (($file = file_get_contents($parameters['media'])) === false) {
+        if (($file = @file_get_contents($parameters['media'])) === false) {
             throw new \InvalidArgumentException('You must supply a readable file');
         }
         $parameters['media'] = base64_encode($file);


### PR DESCRIPTION
"is_readable" support only URL wrappers from stat() family of functionality. This makes http:// and https:// links to throw Exception. This way you should first download the link to a local storage, which sometimes is not an option.  'file_get_contents" alone does the job. 