### PR TITLE
Add shared parameter from mediaInitParameters

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -352,6 +352,9 @@ class TwitterOAuth extends Config
         if (isset($parameters['media_category'])) {
             $return['media_category'] = $parameters['media_category'];
         }
+        if (isset($parameters['shared'])) {
+            $return['shared'] = $parameters['shared'];
+        }
         return $return;
     }
 


### PR DESCRIPTION
Add shared parameter from mediaInitParameters

https://developer.twitter.com/en/docs/direct-messages/message-attachments/guides/attaching-media.html

```
shared | Set to true if media asset will be reused for multiple Direct Messages. Default is false.
```

Send direct message require `shared` parameter

