### PR TITLE
Allow to get headers of last response

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -91,6 +91,14 @@ class TwitterOAuth extends Config
     /**
      * @return array
      */
+    public function getLastHeaders()
+    {
+        return $this->response->getsHeaders();
+    }
+
+    /**
+     * @return array
+     */
     public function getLastXHeaders()
     {
         return $this->response->getXHeaders();


### PR DESCRIPTION
There are methods like `getLastXHeaders`, `getBody`, but there aren't `getLastHeaders`. Be able to get response headers is pretty important in certain cases (for example, when I got data of attachment in #769 , I want to read content type from response headers instead of tryes to determine it manually), so I expanded bunch of response-scoped methods with this one.

Method `getLastHeaders` allows to read all headers of server response.

Usage example:
```php
$connector = new TwitterOAuth(
    $this->consumer_key,
    $this->consumer_secret,
    $this->access_token,
    $this->access_token_secret
);

$data = $connector->get('some/endpoint');
$headers = $connector->getLastHeaders();
```