### PR TITLE
Update SignatureMethod.php

### DIFF
--- a/src/SignatureMethod.php
+++ b/src/SignatureMethod.php
@@ -58,7 +58,7 @@ abstract class SignatureMethod
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
         for ($i = 0; $i < strlen($signature); $i++) {
-            $result |= ord($built[$i]) ^ ord($signature[$i]);
+            $result = $result | (ord($built[$i]) ^ ord($signature[$i]));
         }
 
         return $result == 0;


### PR DESCRIPTION
fixed 7.4.1 Array and string offset access syntax with curly braces is deprecated