### PR TITLE
use twitter wait time before returning media_id

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -392,6 +392,12 @@ class TwitterOAuth extends Config
             ],
             false
         );
+        
+        if(isset($finalize->processing_info)) {
+            $wait = $finalize->processing_info->check_after_secs;
+	        sleep($wait);
+        }
+        
         return $finalize;
     }
 


### PR DESCRIPTION
After many hour debugging this, turns out the reason I get "Not valid video" error because twitter is still processing the video upload and the video is not ready to be used yet!

However, the POST call return does give you num of secs you need to wait before the video is ready!

![Screenshot 2020-06-14 at 14 55 04](https://user-images.githubusercontent.com/19202935/84595640-e9b82e80-ae50-11ea-99a0-591b181c21c6.png)
