### PR TITLE
Support Twitter API v2

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -20,7 +20,6 @@ use Composer\CaBundle\CaBundle;
  */
 class TwitterOAuth extends Config
 {
-    private const API_VERSION = '1.1';
     private const API_HOST = 'https://api.twitter.com';
     private const UPLOAD_HOST = 'https://upload.twitter.com';
 
@@ -36,6 +35,10 @@ class TwitterOAuth extends Config
     private $signatureMethod;
     /** @var int Number of attempts we made for the request */
     private $attempts = 0;
+    /** @var int The API version */
+    private $apiVersion = '1.1';
+    /** @var string The URL pattern */
+    private $urlPattern = '%s/%s/%s.json';
 
     /**
      * Constructor
@@ -81,6 +84,22 @@ class TwitterOAuth extends Config
     {
         $this->bearer = $oauthTokenSecret;
         $this->token = null;
+    }
+
+    /**
+     */
+    public function useNewApi(): void
+    {
+        $this->apiVersion = 2;
+        $this->urlPattern = '%s/%s/%s';
+    }
+
+    /**
+     */
+    public function useCurrentApi(): void
+    {
+        $this->apiVersion = 1.1;
+        $this->urlPattern = '%s/%s/%s.json';
     }
 
     /**
@@ -459,7 +478,7 @@ class TwitterOAuth extends Config
     ) {
         $this->resetLastResponse();
         $this->resetAttemptsNumber();
-        $url = sprintf('%s/%s/%s.json', $host, self::API_VERSION, $path);
+        $url = sprintf($this->urlPattern, $host, $this->apiVersion, $path);
         $this->response->setApiPath($path);
         if (!$json) {
             $parameters = $this->cleanUpParameters($parameters);


### PR DESCRIPTION
This PR adds two methods: `useNewApi` and `useCurrentApi`.

`useNewApi` will switch to the v2 Twitter API endpoint.
`useCurrentApi` will revert to the v1 Twitter API endpoint.

This would resolve #874 