### PR TITLE
Move url to separate method

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -441,6 +441,11 @@ class TwitterOAuth extends Config
         return $parameters;
     }
 
+    public function getUrl(string $host, string $path)
+    {
+        return sprintf('%s/%s/%s.json', $host, self::API_VERSION, $path);
+    }
+
     /**
      * @param string $method
      * @param string $host
@@ -459,7 +464,7 @@ class TwitterOAuth extends Config
     ) {
         $this->resetLastResponse();
         $this->resetAttemptsNumber();
-        $url = sprintf('%s/%s/%s.json', $host, self::API_VERSION, $path);
+        $url = $this->getUrl($host, $path);
         $this->response->setApiPath($path);
         if (!$json) {
             $parameters = $this->cleanUpParameters($parameters);

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -441,7 +441,7 @@ class TwitterOAuth extends Config
         return $parameters;
     }
 
-    public function getUrl(string $host, string $path)
+    protected function getUrl(string $host, string $path)
     {
         return sprintf('%s/%s/%s.json', $host, self::API_VERSION, $path);
     }


### PR DESCRIPTION
This could resolve #927 and #874

I moved the $url in the method "http" to a separate method, which allows other users to extends this class and change the request url for Twitter API V2, Twitter Ads API and maybe other API versions in the future.

This change is BC.

If you want to use TwitterAds you can do this:

```
/**
 * TwitterAds
 */
class TwitterAds extends TwitterOAuth
{
    private const API_VERSION = '7';
    private const API_HOST = 'https://ads-api.twitter.com';

    /**
     * @inheritDoc
     */
    protected function getUrl(string $host, string $path): string
    {
        return sprintf('%s/%s/%s', self::API_HOST, self::API_VERSION, $path);
    }
}
```

Could you review this @abraham?