### PR TITLE
Get file from DM

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -464,7 +464,24 @@ class TwitterOAuth extends Config
         if (!$json) {
             $parameters = $this->cleanUpParameters($parameters);
         }
-        return $this->makeRequests($url, $method, $parameters, $json);
+        $result = $this->makeRequests($url, $method, $parameters, $json);
+
+        $response = JsonDecoder::decode($result, $this->decodeJsonAsArray);
+        $this->response->setBody($response);
+
+        return $response;
+    }
+
+    /**
+     * Get media file attached to direct message.
+     *
+     * @param string $url
+     * @param array $parameters
+     * @return string
+     */
+    function file(string $url, array $parameters)
+    {
+        return $this->makeRequests($url, 'GET', $parameters, false);
     }
 
     /**
@@ -477,7 +494,7 @@ class TwitterOAuth extends Config
      * @param array  $parameters
      * @param bool   $json
      *
-     * @return array|object
+     * @return string
      */
     private function makeRequests(
         string $url,
@@ -488,13 +505,11 @@ class TwitterOAuth extends Config
         do {
             $this->sleepIfNeeded();
             $result = $this->oAuthRequest($url, $method, $parameters, $json);
-            $response = JsonDecoder::decode($result, $this->decodeJsonAsArray);
-            $this->response->setBody($response);
             $this->attempts++;
             // Retry up to our $maxRetries number if we get errors greater than 500 (over capacity etc)
         } while ($this->requestsAvailable());
 
-        return $response;
+        return $result;
     }
 
     /**

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -479,7 +479,7 @@ class TwitterOAuth extends Config
      * @param array $parameters
      * @return string
      */
-    function getFile(string $url, array $parameters)
+    function getFile(string $url, array $parameters = [])
     {
         return $this->makeRequests($url, 'GET', $parameters, false);
     }

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -479,7 +479,7 @@ class TwitterOAuth extends Config
      * @param array $parameters
      * @return string
      */
-    function file(string $url, array $parameters)
+    function getFile(string $url, array $parameters)
     {
         return $this->makeRequests($url, 'GET', $parameters, false);
     }

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -321,7 +321,8 @@ class TwitterOAuth extends Config
      * Get media file attached to direct message.
      *
      * @param string $url
-     * @param array $parameters
+     * @param array  $parameters
+     *
      * @return string
      */
     public function getFile(string $url, array $parameters = [])

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -318,6 +318,18 @@ class TwitterOAuth extends Config
     }
 
     /**
+     * Get media file attached to direct message.
+     *
+     * @param string $url
+     * @param array $parameters
+     * @return string
+     */
+    public function getFile(string $url, array $parameters = [])
+    {
+        return $this->makeRequests($url, 'GET', $parameters, false);
+    }
+
+    /**
      * Private method to upload media (not chunked) to upload.twitter.com.
      *
      * @param string $path
@@ -470,18 +482,6 @@ class TwitterOAuth extends Config
         $this->response->setBody($response);
 
         return $response;
-    }
-
-    /**
-     * Get media file attached to direct message.
-     *
-     * @param string $url
-     * @param array $parameters
-     * @return string
-     */
-    function getFile(string $url, array $parameters = [])
-    {
-        return $this->makeRequests($url, 'GET', $parameters, false);
     }
 
     /**


### PR DESCRIPTION
Another realizatuion of method to download files from direct messages.
Extract JSON decoding from `makeRequests` method, so it can be used by `getFile` method without any unnecessary conditions.

Alternative to #769 .