### PR TITLE
Remove php 7.3 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0']
     name: PHP ${{ matrix.php-versions }}
     steps:
       - uses: actions/checkout@v2

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
   "singleQuote": true,
-  "phpVersion": "7.3",
+  "phpVersion": "7.4",
   "trailingCommaPHP": true,
   "braceStyle": "psr-2"
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     }
   ],
   "require": {
-    "php": "^7.3 || ^7.4 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "ext-curl": "*",
     "composer/ca-bundle": "^1.2"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "462de928e9afd2f385e1cc2d751c7dfc",
+    "content-hash": "e8a34f26e28f4d2696a9dacb9769afd4",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3317,9 +3317,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ^7.4 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-curl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
PHP 7.3 is about to stop getting security updates. https://www.php.net/supported-versions.php