### PR TITLE
Added host parameter to TwitterOAuth::post() method

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -26,8 +26,8 @@ use Composer\CaBundle\CaBundle;
  */
 class TwitterOAuth extends Config
 {
-    private const API_HOST = 'https://api.twitter.com';
-    private const UPLOAD_HOST = 'https://upload.twitter.com';
+    public const API_HOST = 'https://api.twitter.com';
+    public const UPLOAD_HOST = 'https://upload.twitter.com';
 
     /** @var Response details about the result of the last request */
     private ?Response $response = null;
@@ -249,9 +249,10 @@ class TwitterOAuth extends Config
     public function post(
         string $path,
         array $parameters = [],
-        bool $json = false
+        bool $json = false,
+        string $host = self::API_HOST
     ) {
-        return $this->http('POST', self::API_HOST, $path, $parameters, $json);
+        return $this->http('POST', $host, $path, $parameters, $json);
     }
 
     /**


### PR DESCRIPTION
I created this PR mainly to attach [meta data](https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-metadata-create) to images. There are a couple other endpoints like `media/subtitles/create` or `media/subtitles/delete`, tho, where this change could come in handy.

There is already a similar PR #918, but that PR adds a new method for just the `media/metadata/create` endpoint, whereas this PR allows to set the host on the existing `post` method and can therefore be used for any of the other media endpoints as well. And since there is already a dedicated method for getting the upload status, I only made this change for the `post` method.