### PR TITLE
Replaced endpoint from Twitter's to X's

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -26,8 +26,8 @@ use Composer\CaBundle\CaBundle;
  */
 class TwitterOAuth extends Config
 {
-    private const API_HOST = 'https://api.twitter.com';
-    private const UPLOAD_HOST = 'https://upload.twitter.com';
+    private const API_HOST = 'https://api.x.com';
+    private const UPLOAD_HOST = 'https://upload.x.com';
 
     /** @var Response details about the result of the last request */
     private ?Response $response = null;


### PR DESCRIPTION
Twitter is redirecting api.twitter.com to api.x.com during OAuth and while doing this it forgets the request_token.