### PR TITLE
Only call curl_close() in PHP < 8

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -745,7 +745,9 @@ class TwitterOAuth extends Config
         if (curl_errno($curlHandle) > 0) {
             $error = curl_error($curlHandle);
             $errorNo = curl_errno($curlHandle);
-            curl_close($curlHandle);
+            if (PHP_MAJOR_VERSION < 8) {
+                curl_close($curlHandle);
+            }
             throw new TwitterOAuthException($error, $errorNo);
         }
 
@@ -757,7 +759,9 @@ class TwitterOAuth extends Config
         $responseHeader = array_pop($parts);
         $this->response->setHeaders($this->parseHeaders($responseHeader));
 
-        curl_close($curlHandle);
+        if (PHP_MAJOR_VERSION < 8) {
+            curl_close($curlHandle);
+        }
 
         return $responseBody;
     }


### PR DESCRIPTION
`curl_close()` has had no effect since PHP 8 and is deprecated in PHP 8.5. This fix ensures that it is only called in PHP < 8.